### PR TITLE
Support newer lint versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         ci_java_version: [16]
-        ci_lint_version: [30.0.3]
+        ci_lint_version: [30.0.3, 30.1.0-beta02, 30.2.0-alpha03]
         ci_kotlin_version: [1.5.31]
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ci_java_version: [16]
-        ci_lint_version: [30.0.3, 30.1.0-beta02, 30.2.0-alpha03]
-        ci_kotlin_version: [1.5.31]
+        ci_java_version: ['16']
+        ci_lint_version: ['30.0.3', '30.1.0-beta02', '30.2.0-alpha03']
+        ci_kotlin_version: ['1.5.31']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -46,15 +46,17 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.ci_java_version }}
 
-      - name: Build and run tests
-        id: gradle
+      - name: Build
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: clean check --stacktrace -PlintVersion=${{ matrix.ci_lint_version }} -PkotlinVersion=${{ matrix.ci_kotlin_version }}
+          arguments: spotlessCheck compileKotlin compileTestKotlin --stacktrace -PlintVersion=${{ matrix.ci_lint_version }} -PkotlinVersion=${{ matrix.ci_kotlin_version }}
 
-      - name: Print build scan url
-        if: always()
-        run: echo ${{ steps.gradle.outputs.build-scan-url }}
+      # Test only on current stable because test outputs change wildly between lint versions
+      - name: Check
+        if: matrix.ci_lint_version == '30.0.3'
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: check --stacktrace -PlintVersion=${{ matrix.ci_lint_version }} -PkotlinVersion=${{ matrix.ci_kotlin_version }}
 
       - name: (Fail-only) Bundle the build report
         if: failure()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ buildscript {
 }
 
 plugins {
-  id("com.diffplug.spotless") version "5.17.0"
+  id("com.diffplug.spotless") version "5.1.0"
   id("com.vanniktech.maven.publish") version "0.18.0" apply false
   id("org.jetbrains.dokka") version "1.5.30" apply false
   id("io.gitlab.arturbosch.detekt") version "1.18.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ buildscript {
 }
 
 plugins {
-  id("com.diffplug.spotless") version "5.1.0"
+  id("com.diffplug.spotless") version "5.17.1"
   id("com.vanniktech.maven.publish") version "0.18.0" apply false
   id("org.jetbrains.dokka") version "1.5.30" apply false
   id("io.gitlab.arturbosch.detekt") version "1.18.1"

--- a/slack-lint/src/main/java/slack/lint/MoshiUsageDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/MoshiUsageDetector.kt
@@ -36,6 +36,7 @@ import com.intellij.psi.PsiTypeParameter
 import com.intellij.psi.util.InheritanceUtil.isInheritor
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtCollectionLiteralExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtModifierListOwner
 import org.jetbrains.kotlin.psi.KtParameter
@@ -58,7 +59,6 @@ import org.jetbrains.uast.UReferenceExpression
 import org.jetbrains.uast.getUastParentOfType
 import org.jetbrains.uast.kotlin.KotlinUAnnotation
 import org.jetbrains.uast.kotlin.KotlinUClassLiteralExpression
-import org.jetbrains.uast.kotlin.expressions.KotlinUCollectionLiteralExpression
 import org.jetbrains.uast.toUElement
 import org.jetbrains.uast.toUElementOfType
 import slack.lint.moshi.MoshiLintUtil.hasMoshiAnnotation
@@ -843,8 +843,8 @@ class MoshiUsageDetector : Detector(), SourceCodeScanner {
     member.findAnnotation(FQCN_SERIALIZED_NAME)?.let { serializedName ->
       val name = serializedName.findAttributeValue("value")?.evaluate() as String
       @Suppress("UNCHECKED_CAST")
-      val alternateCount = (serializedName.findAttributeValue("alternate") as? KotlinUCollectionLiteralExpression)
-        ?.valueArgumentCount ?: -1
+      val alternateCount = (serializedName.findAttributeValue("alternate")?.sourcePsi as? KtCollectionLiteralExpression)
+        ?.getInnerExpressions()?.size ?: -1
       val hasAlternates = alternateCount > 0
 
       var fix: LintFix? = null


### PR DESCRIPTION
This updates a few deps and also sets up CI to test compilation against newer versions. Unfortunately we can't also test newer versions on CI because test outputs change slightly between different versions.