### PR TITLE
Implement `@RestrictCallsTo` lint

### DIFF
--- a/slack-lint-annotations/src/main/kotlin/slack/lint/annotations/RestrictCallsTo.kt
+++ b/slack-lint-annotations/src/main/kotlin/slack/lint/annotations/RestrictCallsTo.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint.annotations
+
+import java.lang.annotation.Inherited
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+
+/**
+ * Annotation representing a function or property that should not be called outside of a given
+ * [scope]. Similar to androidx's `RestrictTo` annotation but just for calls.
+ */
+@Inherited
+@Target(CLASS)
+@Retention(RUNTIME)
+annotation class RestrictCallsTo(
+  /**
+   * The target scope. Only file is supported for now, toe-hold left for possible future scopes.
+   */
+  val scope: Int = FILE
+) {
+  companion object {
+    const val FILE = 0
+  }
+}

--- a/slack-lint/src/main/java/slack/lint/RestrictCallsToDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/RestrictCallsToDetector.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UFile
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.getContainingUFile
+import org.jetbrains.uast.resolveToUElement
+import org.jetbrains.uast.toUElementOfType
+import slack.lint.util.sourceImplementation
+
+class RestrictCallsToDetector : Detector(), SourceCodeScanner {
+
+  companion object {
+    val ISSUE: Issue = Issue.create(
+      "RestrictCallsTo",
+      "Methods annotated with @RestrictedCallsTo should only be called from the specified scope.",
+      """
+          This method is intended to only be called from the specified scope despite it being \
+          public. This could be due to its use in an interface or similar. Overrides are still \
+          ok.
+      """,
+      Category.CORRECTNESS,
+      6,
+      Severity.ERROR,
+      sourceImplementation<RestrictCallsToDetector>()
+    )
+
+    private const val RESTRICT_CALLS_TO_ANNOTATION = "slack.lint.annotations.RestrictCallsTo"
+  }
+
+  override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
+
+  override fun createUastHandler(context: JavaContext) = object : UElementHandler() {
+
+    @Suppress("UNUSED_VARIABLE") // Toe-hold for now until we support other scopes
+    override fun visitCallExpression(node: UCallExpression) {
+      val method = node.resolveToUElement() as? UMethod ?: return
+
+      val (restrictCallsTo, annotatedMethod) = method.superMethodSequence()
+        .mapNotNull { superMethod ->
+          superMethod.findAnnotation(RESTRICT_CALLS_TO_ANNOTATION)?.let {
+            it to superMethod
+          }
+        }
+        .firstOrNull() ?: return
+
+      val containingFile = annotatedMethod.getContainingUFile() ?: return
+      val callingFile = node.getContainingUFile() ?: return
+      if (!callingFile.isSameAs(containingFile)) {
+        context.report(
+          ISSUE,
+          node,
+          context.getLocation(node),
+          ISSUE.getBriefDescription(TextFormat.TEXT)
+        )
+      }
+    }
+
+    private fun UMethod.superMethodSequence(): Sequence<UMethod> {
+      return generateSequence(this) {
+        if (context.evaluator.isOverride(it)) {
+          // Note this doesn't try to check multiple interfaces, but we can fix that in the future
+          // if it matters
+          it.findSuperMethods()[0].toUElementOfType()
+        } else {
+          null
+        }
+      }
+    }
+  }
+
+  // UFile isn't inherently comparable, so package and simple name are close enough for us.
+  private fun UFile.isSameAs(other: UFile): Boolean {
+    return this.packageName == other.packageName && this.sourcePsi.name == other.sourcePsi.name
+  }
+}

--- a/slack-lint/src/main/java/slack/lint/SlackIssueRegistry.kt
+++ b/slack-lint/src/main/java/slack/lint/SlackIssueRegistry.kt
@@ -61,5 +61,6 @@ class SlackIssueRegistry : IssueRegistry() {
     *RedactedUsageDetector.ISSUES,
     InjectInJavaDetector.ISSUE,
     RetrofitUsageDetector.ISSUE,
+    RestrictCallsToDetector.ISSUE,
   )
 }

--- a/slack-lint/src/test/java/slack/lint/RestrictCallsToDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/RestrictCallsToDetectorTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint
+
+import org.junit.Test
+
+class RestrictCallsToDetectorTest : BaseSlackLintTest() {
+
+  private companion object {
+    private val restrictCallsTo = kotlin(
+      """
+        package slack.lint.annotations
+        import java.lang.annotation.Inherited
+
+        @Inherited
+        annotation class RestrictCallsTo(val scope: Int) {
+          companion object {
+            const val FILE = 0
+          }
+        }
+      """
+    ).indented()
+  }
+
+  override fun getDetector() = RestrictCallsToDetector()
+  override fun getIssues() = listOf(RestrictCallsToDetector.ISSUE)
+
+  @Test
+  fun smokeTest() {
+    lint()
+      .files(
+        restrictCallsTo,
+        kotlin(
+          """
+          package foo
+
+          import slack.lint.annotations.RestrictCallsTo
+          import slack.lint.annotations.RestrictCallsTo.Companion.FILE
+
+          interface MyApi {
+            fun example()
+
+            @RestrictCallsTo(FILE)
+            fun annotatedExample()
+          }
+
+          class SameFile {
+            fun doStuffWith(api: MyApi) {
+              // This is ok
+              api.example()
+              api.annotatedExample()
+            }
+          }
+
+          class MyApiImpl : MyApi {
+            override fun example() {
+              annotatedExample()
+            }
+
+            // Note this is not annotated, ensures we check up the hierarchy
+            override fun annotatedExample() {
+              println("Hello")
+            }
+          }
+        """
+        ).indented(),
+        kotlin(
+          """
+          package foo
+
+          class DifferentFile {
+            fun doStuffWith(api: MyApi) {
+              // This is ok
+              api.example()
+              // This is not
+              api.annotatedExample()
+            }
+          }
+
+          class MyApiImpl2 : MyApi {
+            override fun example() {
+              // Not ok
+              annotatedExample()
+            }
+
+            // Still ok
+            override fun annotatedExample() {
+              println("Hello")
+            }
+
+            fun backdoor() {
+              // Backdoors don't work either! This isn't annotated on the impl but we check the
+              // original overridden type.
+              MyApiImpl().annotatedExample()
+            }
+          }
+        """
+        ).indented(),
+      )
+      .allowCompilationErrors(false)
+      .run()
+      .expect(
+        """
+        src/foo/DifferentFile.kt:8: Error: Methods annotated with @RestrictedCallsTo should only be called from the specified scope. [RestrictCallsTo]
+            api.annotatedExample()
+            ~~~~~~~~~~~~~~~~~~~~~~
+        src/foo/DifferentFile.kt:15: Error: Methods annotated with @RestrictedCallsTo should only be called from the specified scope. [RestrictCallsTo]
+            annotatedExample()
+            ~~~~~~~~~~~~~~~~~~
+        src/foo/DifferentFile.kt:26: Error: Methods annotated with @RestrictedCallsTo should only be called from the specified scope. [RestrictCallsTo]
+            MyApiImpl().annotatedExample()
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        3 errors, 0 warnings
+        """.trimIndent()
+      )
+  }
+}


### PR DESCRIPTION
This implements a new detector for a new `@RestrictCallsTo` annotation. This is similar to `@RestrictTo`, but is specifically just targeted at `UCallExpression`s. This is useful for APIs that can be safely implemented but are not expected to be _called_ externally, such as overrides for lifecycle callbacks.