### PR TITLE
Hunvil and josh/span point mark

### DIFF
--- a/slack-lint/src/main/java/slack/lint/SlackIssueRegistry.kt
+++ b/slack-lint/src/main/java/slack/lint/SlackIssueRegistry.kt
@@ -27,6 +27,7 @@ import slack.lint.mocking.DoNotMockMockDetector
 import slack.lint.mocking.ErrorProneDoNotMockDetector
 import slack.lint.retrofit.RetrofitUsageDetector
 import slack.lint.rx.RxSubscribeOnMainDetector
+import slack.lint.text.SpanPointMarkDangerousCheckDetector
 
 @AutoService(IssueRegistry::class)
 class SlackIssueRegistry : IssueRegistry() {
@@ -61,5 +62,6 @@ class SlackIssueRegistry : IssueRegistry() {
     *RedactedUsageDetector.ISSUES,
     InjectInJavaDetector.ISSUE,
     RetrofitUsageDetector.ISSUE,
+    SpanPointMarkDangerousCheckDetector.ISSUE,
   )
 }

--- a/slack-lint/src/main/java/slack/lint/text/SpanPointMarkDangerousCheckDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/text/SpanPointMarkDangerousCheckDetector.kt
@@ -1,0 +1,102 @@
+package slack.lint.text
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
+import com.android.tools.lint.detector.api.Location
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.XmlContext
+import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.PsiType
+import org.jetbrains.uast.UBinaryExpression
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.sourcePsiElement
+import org.w3c.dom.Element
+import slack.lint.retrofit.RetrofitUsageDetector
+import slack.lint.rx.RxSubscribeOnMainDetector
+import slack.lint.util.removeNode
+import slack.lint.util.sourceImplementation
+import java.util.regex.Pattern
+
+class SpanPointMarkDangerousCheckDetector : Detector(), SourceCodeScanner {
+
+    companion object {
+        private fun Implementation.toIssue() = Issue.create(
+            id = "SpanPointMarkDangerousCheck",
+            briefDescription = "my desc.",
+            explanation = """
+        Spans flags can have priority or other bits set. Check using `currentFlag and Spanned.SPAN_POINT_MARK_MASK == desiredFlag` 
+      """,
+            category = Category.CORRECTNESS,
+            priority = 4,
+            severity = Severity.ERROR,
+            implementation = this
+        )
+
+        val ISSUE = sourceImplementation<SpanPointMarkDangerousCheckDetector>().toIssue()
+
+        private const val MARK_POINT =
+            "(Spanned.)?(INCLUSIVE_INCLUSIVE|INCLUSIVE_EXCLUSIVE|EXCLUSIVE_INCLUSIVE|EXCLUSIVE_EXCLUSIVE)"
+        private const val FLAG_WITHOUT_MASK = "((?!\\b+and\\s+SPAN_POINT_MARK_MASK\\b).)*"
+        private const val EQUALITY_OPERATOR = "((==)|(\\!=))"
+        val regex = Regex(
+            "(^($FLAG_WITHOUT_MASK)\\s*$EQUALITY_OPERATOR\\s*($MARK_POINT)$)|" +
+                    "(^($MARK_POINT)\\s*$EQUALITY_OPERATOR\\s*($FLAG_WITHOUT_MASK)$)"
+        )
+    }
+
+    override fun getApplicableUastTypes() = listOf(UBinaryExpression::class.java)
+
+    /**
+     *
+     * For next time:
+     *
+     * Figure out how to only match the smallest binary expression that matches for each line:
+     * Currently it matches twice.
+     *
+     * Matches are [0 Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()) || Spanned.x(), 1 null, 2 null, 3 null, 4 null, 5 null, 6 null, 7 null, 8 null, 9 null, 10 Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()) || Spanned.x(), 11 Spanned.INCLUSIVE_INCLUSIVE, 12 Spanned., 13 INCLUSIVE_INCLUSIVE, 14 !=, 15 null, 16 !=, 17 spanned.getSpanFlags(Object()) || Spanned.x(), 18 )]
+        Matches are [0 Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()), 1 null, 2 null, 3 null, 4 null, 5 null, 6 null, 7 null, 8 null, 9 null, 10 Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()), 11 Spanned.INCLUSIVE_INCLUSIVE, 12 Spanned., 13 INCLUSIVE_INCLUSIVE, 14 !=, 15 null, 16 !=, 17 spanned.getSpanFlags(Object()), 18 )]
+
+     */
+
+    override fun createUastHandler(context: JavaContext): UElementHandler {
+        System.out.println("regex" + regex.toString())
+        return object : UElementHandler() {
+            override fun visitBinaryExpression(node: UBinaryExpression) {
+                val text = node.sourcePsi?.text ?: return
+                val match = regex.find(text) ?: return
+                System.out.println("Matches are " + match.groups.mapIndexed { i, group -> "$i ${group?.value}" })
+                val markPoint = (match.groups[7] ?: match.groups[11])!!.value
+                val flagWithoutMask = (match.groups[2] ?: match.groups[10])!!.value
+
+                /*
+                Matches are [0 spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE, 1 spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE, 2 spanned.getSpanFlags(Object()) , 3  , 4 !=, 5 null, 6 !=, 7 Spanned.INCLUSIVE_INCLUSIVE, 8 Spanned., 9 INCLUSIVE_INCLUSIVE, 10 null, 11 null, 12 null, 13 null, 14 null, 15 null, 16 null, 17 null, 18 null]
+                 */
+                val equality = (match.groups[5] ?: match.groups[6] ?: match.groups[15] ?: match.groups[16])!!.value
+                context.report(
+                    ISSUE,
+                    context.getLocation(node),
+                    "Do not check against $markPoint directly. " +
+                            "Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags.",
+                    LintFix.create()
+                        .replace()
+                        .name("Use bitwise mask")
+                        .text(match.groups[0]!!.value)
+                        .with("($flagWithoutMask) and Spanned.SPAN_POINT_MARK_MASK $equality $markPoint")
+                        .build()
+                )
+            }
+        }
+    }
+
+}

--- a/slack-lint/src/test/java/slack/lint/text/SpanPointMarkDangerousCheckDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/text/SpanPointMarkDangerousCheckDetectorTest.kt
@@ -7,13 +7,30 @@ import slack.lint.BaseSlackLintTest
 import slack.lint.rx.RxSubscribeOnMainDetector
 import slack.lint.rx.rxJavaJar3
 
+/**
+ * Tests [SpanPointMarkDangerousCheckDetector].
+ */
 class SpanPointMarkDangerousCheckDetectorTest : BaseSlackLintTest() {
 
     override fun getDetector() = SpanPointMarkDangerousCheckDetector()
     override fun getIssues() = listOf(SpanPointMarkDangerousCheckDetector.ISSUE)
 
+    private val androidTextStubs = kotlin(
+        """
+        package android.text
+
+        object Spanned {
+            const val INCLUSIVE_INCLUSIVE = 1
+            const val INCLUSIVE_EXCLUSIVE = 2
+            const val EXCLUSIVE_INCLUSIVE = 3
+            const val EXCLUSIVE_EXCLUSIVE = 4
+            const val SPAN_POINT_MARK_MASK = 0xFF
+        }
+      """
+    ).indented()
+
     @Test
-    fun `visitBinaryExpression - given violating file with equality and flag on right - creates error and fix`() {
+    fun `visitBinaryExpression - given conforming expression - has clean report`() {
         @Language("kotlin")
         val testFile = kotlin(
             """
@@ -22,35 +39,40 @@ class SpanPointMarkDangerousCheckDetectorTest : BaseSlackLintTest() {
               import android.text.Spanned
         
               class MyClass {
-                  fun doCheck(spanned: Spanned): Boolean {
-                    return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                  fun doCheckCorrectly(spanned: Spanned): Boolean {
+                    return spanned.getSpanFlags(Object()) and Spanned.SPAN_POINT_MARK_MASK == Spanned.INCLUSIVE_INCLUSIVE
                   }
               }
             """
         ).indented()
         lint()
-            .files(testFile)
+            .files(androidTextStubs, testFile)
             .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
             .run()
-            .expect(
-                """
-                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
-                      return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                1 errors, 0 warnings
-                """.trimIndent()
-            )
-            .expectFixDiffs(
-                """
-                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
-                @@ -7 +7
-                -       return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                """.trimIndent()
-            )
+            .expectClean()
     }
+
     @Test
-    fun `visitBinaryExpression - given violating file with equality and flag on left - creates error and fix`() {
+    fun `visitBinaryExpression - given violating expression with INCLUSIVE_INCLUSIVE - creates error and fix`() {
+        testViolatingExpression("Spanned.INCLUSIVE_INCLUSIVE")
+    }
+
+    @Test
+    fun `visitBinaryExpression - given violating expression with INCLUSIVE_EXCLUSIVE - creates error and fix`() {
+        testViolatingExpression("Spanned.INCLUSIVE_EXCLUSIVE")
+    }
+
+    @Test
+    fun `visitBinaryExpression - given violating expression with EXCLUSIVE_INCLUSIVE - creates error and fix`() {
+        testViolatingExpression("Spanned.EXCLUSIVE_INCLUSIVE")
+    }
+
+    @Test
+    fun `visitBinaryExpression - given violating expression with EXCLUSIVE_EXCLUSIVE - creates error and fix`() {
+        testViolatingExpression("Spanned.EXCLUSIVE_EXCLUSIVE")
+    }
+
+    private fun testViolatingExpression(markPoint: String) {
         @Language("kotlin")
         val testFile = kotlin(
             """
@@ -59,20 +81,20 @@ class SpanPointMarkDangerousCheckDetectorTest : BaseSlackLintTest() {
               import android.text.Spanned
         
               class MyClass {
-                  fun doCheck(spanned: Spanned): Boolean {
-                    return Spanned.INCLUSIVE_INCLUSIVE == spanned.getSpanFlags(Object()) || Spanned.x()
+                  fun doCheckIncorrectly(spanned: Spanned): Boolean {
+                    return spanned.getSpanFlags(Object()) == $markPoint || Spanned.x()
                   }
               }
             """
         ).indented()
         lint()
-            .files(testFile)
+            .files(androidTextStubs, testFile)
             .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
             .run()
             .expect(
                 """
-                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
-                      return Spanned.INCLUSIVE_INCLUSIVE == spanned.getSpanFlags(Object()) || Spanned.x()
+                src/slack/text/MyClass.kt:7: Error: Do not check against $markPoint directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
+                      return spanned.getSpanFlags(Object()) == $markPoint || Spanned.x()
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 1 errors, 0 warnings
                 """.trimIndent()
@@ -81,85 +103,10 @@ class SpanPointMarkDangerousCheckDetectorTest : BaseSlackLintTest() {
                 """
                 Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
                 @@ -7 +7
-                -       return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                -       return spanned.getSpanFlags(Object()) == $markPoint || Spanned.x()
+                +       return ((spanned.getSpanFlags(Object())) and android.text.Spanned.SPAN_POINT_MARK_MASK) == $markPoint || Spanned.x()
                 """.trimIndent()
             )
     }
 
-    @Test
-    fun `visitBinaryExpression - given violating file with inequality and flag on right - creates error and fix`() {
-        @Language("kotlin")
-        val testFile = kotlin(
-            """
-                package slack.text
-        
-              import android.text.Spanned
-        
-              class MyClass {
-                  fun doCheck(spanned: Spanned): Boolean {
-                    return spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                  }
-              }
-            """
-        ).indented()
-        lint()
-            .files(testFile)
-            .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
-            .run()
-            .expect(
-                """
-                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
-                      return spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                1 errors, 0 warnings
-                """.trimIndent()
-            )
-            .expectFixDiffs(
-                """
-                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
-                @@ -7 +7
-                -       return spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                """.trimIndent()
-            )
-    }
-
-    @Test
-    fun `visitBinaryExpression - given violating file with inequality and flag on left - creates error and fix`() {
-        @Language("kotlin")
-        val testFile = kotlin(
-            """
-                package slack.text
-        
-              import android.text.Spanned
-        
-              class MyClass {
-                  fun doCheck(spanned: Spanned): Boolean {
-                    return Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()) || Spanned.x()
-                  }
-              }
-            """
-        ).indented()
-        lint()
-            .files(testFile)
-            .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
-            .run()
-            .expect(
-                """
-                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
-                      return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                1 errors, 0 warnings
-                """.trimIndent()
-            )
-            .expectFixDiffs(
-                """
-                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
-                @@ -7 +7
-                -       return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                """.trimIndent()
-            )
-    }
 }

--- a/slack-lint/src/test/java/slack/lint/text/SpanPointMarkDangerousCheckDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/text/SpanPointMarkDangerousCheckDetectorTest.kt
@@ -1,0 +1,165 @@
+package slack.lint.text
+
+import org.intellij.lang.annotations.Language
+import org.junit.Assert.*
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+import slack.lint.rx.RxSubscribeOnMainDetector
+import slack.lint.rx.rxJavaJar3
+
+class SpanPointMarkDangerousCheckDetectorTest : BaseSlackLintTest() {
+
+    override fun getDetector() = SpanPointMarkDangerousCheckDetector()
+    override fun getIssues() = listOf(SpanPointMarkDangerousCheckDetector.ISSUE)
+
+    @Test
+    fun `visitBinaryExpression - given violating file with equality and flag on right - creates error and fix`() {
+        @Language("kotlin")
+        val testFile = kotlin(
+            """
+                package slack.text
+        
+              import android.text.Spanned
+        
+              class MyClass {
+                  fun doCheck(spanned: Spanned): Boolean {
+                    return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                  }
+              }
+            """
+        ).indented()
+        lint()
+            .files(testFile)
+            .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
+                      return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent()
+            )
+            .expectFixDiffs(
+                """
+                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
+                @@ -7 +7
+                -       return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                """.trimIndent()
+            )
+    }
+    @Test
+    fun `visitBinaryExpression - given violating file with equality and flag on left - creates error and fix`() {
+        @Language("kotlin")
+        val testFile = kotlin(
+            """
+                package slack.text
+        
+              import android.text.Spanned
+        
+              class MyClass {
+                  fun doCheck(spanned: Spanned): Boolean {
+                    return Spanned.INCLUSIVE_INCLUSIVE == spanned.getSpanFlags(Object()) || Spanned.x()
+                  }
+              }
+            """
+        ).indented()
+        lint()
+            .files(testFile)
+            .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
+                      return Spanned.INCLUSIVE_INCLUSIVE == spanned.getSpanFlags(Object()) || Spanned.x()
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent()
+            )
+            .expectFixDiffs(
+                """
+                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
+                @@ -7 +7
+                -       return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `visitBinaryExpression - given violating file with inequality and flag on right - creates error and fix`() {
+        @Language("kotlin")
+        val testFile = kotlin(
+            """
+                package slack.text
+        
+              import android.text.Spanned
+        
+              class MyClass {
+                  fun doCheck(spanned: Spanned): Boolean {
+                    return spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                  }
+              }
+            """
+        ).indented()
+        lint()
+            .files(testFile)
+            .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
+                      return spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent()
+            )
+            .expectFixDiffs(
+                """
+                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
+                @@ -7 +7
+                -       return spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `visitBinaryExpression - given violating file with inequality and flag on left - creates error and fix`() {
+        @Language("kotlin")
+        val testFile = kotlin(
+            """
+                package slack.text
+        
+              import android.text.Spanned
+        
+              class MyClass {
+                  fun doCheck(spanned: Spanned): Boolean {
+                    return Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()) || Spanned.x()
+                  }
+              }
+            """
+        ).indented()
+        lint()
+            .files(testFile)
+            .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
+                      return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent()
+            )
+            .expectFixDiffs(
+                """
+                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
+                @@ -7 +7
+                -       return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                """.trimIndent()
+            )
+    }
+}


### PR DESCRIPTION
###  Summary

Spans flags can have priority or other bits set. Ensure that Span flags are checked using `currentFlag and Spanned.SPAN_POINT_MARK_MASK == desiredFlag` rather than just `currentFlag == desiredFlag` 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
