### PR TITLE
Call out the deprecated call in the lint message when reporting

### DIFF
--- a/slack-lint/src/main/java/slack/lint/DeprecatedAnnotationDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/DeprecatedAnnotationDetector.kt
@@ -41,55 +41,55 @@ private const val BRIEF_DESCRIPTION_SUFFIX = " is deprecated; consider using an 
  */
 class DeprecatedAnnotationDetector : AnnotatedClassOrMethodUsageDetector() {
 
-    override val annotationNames = listOf(DEPRECATED_ANNOTATION_NAME_KOTLIN, DEPRECATED_ANNOTATION_NAME_JAVA)
-    override val issue = ISSUE_DEPRECATED_CALL
+  override val annotationNames = listOf(DEPRECATED_ANNOTATION_NAME_KOTLIN, DEPRECATED_ANNOTATION_NAME_JAVA)
+  override val issue = ISSUE_DEPRECATED_CALL
 
-    // Only enable on CLI
-    override val isEnabled: Boolean
-        get() = !LintClient.isStudio
+  // Only enable on CLI
+  override val isEnabled: Boolean
+    get() = !LintClient.isStudio
 
-    override fun visitAnnotationUsage(
-            context: JavaContext,
-            usage: UElement,
-            type: AnnotationUsageType,
-            annotation: UAnnotation,
-            qualifiedName: String,
-            method: PsiMethod?,
-            referenced: PsiElement?,
-            annotations: List<UAnnotation>,
-            allMemberAnnotations: List<UAnnotation>,
-            allClassAnnotations: List<UAnnotation>,
-            allPackageAnnotations: List<UAnnotation>
-    ) {
-        if (isEnabled && applicableAnnotations().contains(qualifiedName)) {
-            val issueToReport = issue
-            val location = context.getLocation(usage)
-            val messagePrefix = referenced?.let(UastLintUtils.Companion::getQualifiedName)
-                    ?: BRIEF_DESCRIPTION_PREFIX_DEFAULT
-            report(
-                    context,
-                    issueToReport,
-                    usage,
-                    location,
-                    messagePrefix + BRIEF_DESCRIPTION_SUFFIX,
-                    null
-            )
-        }
+  override fun visitAnnotationUsage(
+    context: JavaContext,
+    usage: UElement,
+    type: AnnotationUsageType,
+    annotation: UAnnotation,
+    qualifiedName: String,
+    method: PsiMethod?,
+    referenced: PsiElement?,
+    annotations: List<UAnnotation>,
+    allMemberAnnotations: List<UAnnotation>,
+    allClassAnnotations: List<UAnnotation>,
+    allPackageAnnotations: List<UAnnotation>
+  ) {
+    if (isEnabled && applicableAnnotations().contains(qualifiedName)) {
+      val issueToReport = issue
+      val location = context.getLocation(usage)
+      val messagePrefix = referenced?.let(UastLintUtils.Companion::getQualifiedName)
+        ?: BRIEF_DESCRIPTION_PREFIX_DEFAULT
+      report(
+        context,
+        issueToReport,
+        usage,
+        location,
+        messagePrefix + BRIEF_DESCRIPTION_SUFFIX,
+        null
+      )
+    }
+  }
+
+  companion object {
+    private fun Implementation.toIssue(): Issue {
+      return Issue.create(
+        "DeprecatedCall",
+        BRIEF_DESCRIPTION_PREFIX_DEFAULT + BRIEF_DESCRIPTION_SUFFIX,
+        "Using deprecated classes is not advised; please consider using an alternative.",
+        Category.CORRECTNESS,
+        Priorities.NORMAL,
+        Severity.WARNING,
+        this
+      )
     }
 
-    companion object {
-        private fun Implementation.toIssue(): Issue {
-            return Issue.create(
-                    "DeprecatedCall",
-                    BRIEF_DESCRIPTION_PREFIX_DEFAULT + BRIEF_DESCRIPTION_SUFFIX,
-                    "Using deprecated classes is not advised; please consider using an alternative.",
-                    Category.CORRECTNESS,
-                    Priorities.NORMAL,
-                    Severity.WARNING,
-                    this
-            )
-        }
-
-        val ISSUE_DEPRECATED_CALL = sourceImplementation<DeprecatedAnnotationDetector>().toIssue()
-    }
+    val ISSUE_DEPRECATED_CALL = sourceImplementation<DeprecatedAnnotationDetector>().toIssue()
+  }
 }

--- a/slack-lint/src/main/java/slack/lint/DeprecatedAnnotationDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/DeprecatedAnnotationDetector.kt
@@ -16,7 +16,13 @@
 package slack.lint
 
 import com.android.tools.lint.client.api.LintClient
-import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.AnnotationUsageType
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.UastLintUtils
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
 import org.jetbrains.uast.UAnnotation
@@ -26,7 +32,7 @@ import slack.lint.util.sourceImplementation
 
 private const val DEPRECATED_ANNOTATION_NAME_JAVA = "java.lang.Deprecated"
 private const val DEPRECATED_ANNOTATION_NAME_KOTLIN = "kotlin.Deprecated"
-private const val BRIEF_DESCTIPIOTN_PREFIX_DEFAULT = "This class or method"
+private const val BRIEF_DESCRIPTION_PREFIX_DEFAULT = "This class or method"
 private const val BRIEF_DESCRIPTION_SUFFIX = " is deprecated; consider using an alternative."
 
 /**
@@ -35,52 +41,55 @@ private const val BRIEF_DESCRIPTION_SUFFIX = " is deprecated; consider using an 
  */
 class DeprecatedAnnotationDetector : AnnotatedClassOrMethodUsageDetector() {
 
-  override val annotationNames = listOf(DEPRECATED_ANNOTATION_NAME_KOTLIN, DEPRECATED_ANNOTATION_NAME_JAVA)
-  override val issue = ISSUE_DEPRECATED_CALL
+    override val annotationNames = listOf(DEPRECATED_ANNOTATION_NAME_KOTLIN, DEPRECATED_ANNOTATION_NAME_JAVA)
+    override val issue = ISSUE_DEPRECATED_CALL
 
-  // Only enable on CLI
-  override val isEnabled: Boolean
-    get() = !LintClient.isStudio
+    // Only enable on CLI
+    override val isEnabled: Boolean
+        get() = !LintClient.isStudio
 
-  override fun visitAnnotationUsage(context: JavaContext,
-                                    usage: UElement,
-                                    type: AnnotationUsageType,
-                                    annotation: UAnnotation,
-                                    qualifiedName: String,
-                                    method: PsiMethod?,
-                                    referenced: PsiElement?,
-                                    annotations: List<UAnnotation>,
-                                    allMemberAnnotations: List<UAnnotation>,
-                                    allClassAnnotations: List<UAnnotation>,
-                                    allPackageAnnotations: List<UAnnotation>) {
-    if (isEnabled && applicableAnnotations().contains(qualifiedName)) {
-      val issueToReport = issue
-      val location = context.getLocation(usage)
-      val messagePrefix = referenced?.let(UastLintUtils.Companion::getQualifiedName) ?: BRIEF_DESCTIPIOTN_PREFIX_DEFAULT
-      report(
-              context,
-              issueToReport,
-              usage,
-              location,
-              messagePrefix + BRIEF_DESCRIPTION_SUFFIX,
-              null
-      )
-    }
-  }
-
-  companion object {
-    private fun Implementation.toIssue(): Issue {
-      return Issue.create(
-        "DeprecatedCall",
-        BRIEF_DESCTIPIOTN_PREFIX_DEFAULT + BRIEF_DESCRIPTION_SUFFIX,
-        "Using deprecated classes is not advised; please consider using an alternative.",
-        Category.CORRECTNESS,
-        Priorities.NORMAL,
-        Severity.WARNING,
-        this
-      )
+    override fun visitAnnotationUsage(
+            context: JavaContext,
+            usage: UElement,
+            type: AnnotationUsageType,
+            annotation: UAnnotation,
+            qualifiedName: String,
+            method: PsiMethod?,
+            referenced: PsiElement?,
+            annotations: List<UAnnotation>,
+            allMemberAnnotations: List<UAnnotation>,
+            allClassAnnotations: List<UAnnotation>,
+            allPackageAnnotations: List<UAnnotation>
+    ) {
+        if (isEnabled && applicableAnnotations().contains(qualifiedName)) {
+            val issueToReport = issue
+            val location = context.getLocation(usage)
+            val messagePrefix = referenced?.let(UastLintUtils.Companion::getQualifiedName)
+                    ?: BRIEF_DESCRIPTION_PREFIX_DEFAULT
+            report(
+                    context,
+                    issueToReport,
+                    usage,
+                    location,
+                    messagePrefix + BRIEF_DESCRIPTION_SUFFIX,
+                    null
+            )
+        }
     }
 
-    val ISSUE_DEPRECATED_CALL = sourceImplementation<DeprecatedAnnotationDetector>().toIssue()
-  }
+    companion object {
+        private fun Implementation.toIssue(): Issue {
+            return Issue.create(
+                    "DeprecatedCall",
+                    BRIEF_DESCRIPTION_PREFIX_DEFAULT + BRIEF_DESCRIPTION_SUFFIX,
+                    "Using deprecated classes is not advised; please consider using an alternative.",
+                    Category.CORRECTNESS,
+                    Priorities.NORMAL,
+                    Severity.WARNING,
+                    this
+            )
+        }
+
+        val ISSUE_DEPRECATED_CALL = sourceImplementation<DeprecatedAnnotationDetector>().toIssue()
+    }
 }

--- a/slack-lint/src/main/java/slack/lint/DeprecatedAnnotationDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/DeprecatedAnnotationDetector.kt
@@ -16,12 +16,18 @@
 package slack.lint
 
 import com.android.tools.lint.client.api.LintClient
-import com.android.tools.lint.detector.api.Category
-import com.android.tools.lint.detector.api.Implementation
-import com.android.tools.lint.detector.api.Issue
-import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.*
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UAnnotation
+import org.jetbrains.uast.UElement
 import slack.lint.util.Priorities
 import slack.lint.util.sourceImplementation
+
+private const val DEPRECATED_ANNOTATION_NAME_JAVA = "java.lang.Deprecated"
+private const val DEPRECATED_ANNOTATION_NAME_KOTLIN = "kotlin.Deprecated"
+private const val BRIEF_DESCTIPIOTN_PREFIX_DEFAULT = "This class or method"
+private const val BRIEF_DESCRIPTION_SUFFIX = " is deprecated; consider using an alternative."
 
 /**
  * Raises a warning whenever we use deprecated methods or classes. Generally used for keeping track of health score.
@@ -36,14 +42,37 @@ class DeprecatedAnnotationDetector : AnnotatedClassOrMethodUsageDetector() {
   override val isEnabled: Boolean
     get() = !LintClient.isStudio
 
-  companion object {
-    private const val DEPRECATED_ANNOTATION_NAME_JAVA = "java.lang.Deprecated"
-    private const val DEPRECATED_ANNOTATION_NAME_KOTLIN = "kotlin.Deprecated"
+  override fun visitAnnotationUsage(context: JavaContext,
+                                    usage: UElement,
+                                    type: AnnotationUsageType,
+                                    annotation: UAnnotation,
+                                    qualifiedName: String,
+                                    method: PsiMethod?,
+                                    referenced: PsiElement?,
+                                    annotations: List<UAnnotation>,
+                                    allMemberAnnotations: List<UAnnotation>,
+                                    allClassAnnotations: List<UAnnotation>,
+                                    allPackageAnnotations: List<UAnnotation>) {
+    if (isEnabled && applicableAnnotations().contains(qualifiedName)) {
+      val issueToReport = issue
+      val location = context.getLocation(usage)
+      val messagePrefix = referenced?.let(UastLintUtils.Companion::getQualifiedName) ?: BRIEF_DESCTIPIOTN_PREFIX_DEFAULT
+      report(
+              context,
+              issueToReport,
+              usage,
+              location,
+              messagePrefix + BRIEF_DESCRIPTION_SUFFIX,
+              null
+      )
+    }
+  }
 
+  companion object {
     private fun Implementation.toIssue(): Issue {
       return Issue.create(
         "DeprecatedCall",
-        "This class or method is deprecated; consider using an alternative.",
+        BRIEF_DESCTIPIOTN_PREFIX_DEFAULT + BRIEF_DESCRIPTION_SUFFIX,
         "Using deprecated classes is not advised; please consider using an alternative.",
         Category.CORRECTNESS,
         Priorities.NORMAL,

--- a/slack-lint/src/test/java/slack/lint/DeprecatedAnnotationDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/DeprecatedAnnotationDetectorTest.kt
@@ -247,7 +247,7 @@ class DeprecatedAnnotationDetectorTest : BaseSlackLintTest() {
   private val NON_DEPRECATED_CLASS = java(
     """
         package slack.test;
-        
+
         import java.lang.Deprecated;
 
         class ThisIsNotDeprecated {

--- a/slack-lint/src/test/java/slack/lint/DeprecatedAnnotationDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/DeprecatedAnnotationDetectorTest.kt
@@ -129,7 +129,7 @@ class DeprecatedAnnotationDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/slack/test/TestClass.java:8: Warning: This class or method is deprecated; consider using an alternative. [DeprecatedCall]
+          src/slack/test/TestClass.java:8: Warning: slack.test.ThisIsNotDeprecated.thisIsDeprecated is deprecated; consider using an alternative. [DeprecatedCall]
               new ThisIsNotDeprecated().thisIsDeprecated();
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           0 errors, 1 warnings
@@ -161,7 +161,7 @@ class DeprecatedAnnotationDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/slack/test/TestClass.kt:8: Warning: This class or method is deprecated; consider using an alternative. [DeprecatedCall]
+          src/slack/test/TestClass.kt:8: Warning: slack.test.ThisIsNotDeprecated.thisIsDeprecated is deprecated; consider using an alternative. [DeprecatedCall]
               ThisIsNotDeprecated().thisIsDeprecated()
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           0 errors, 1 warnings
@@ -193,7 +193,7 @@ class DeprecatedAnnotationDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/slack/test/TestClass.kt:8: Warning: This class or method is deprecated; consider using an alternative. [DeprecatedCall]
+          src/slack/test/TestClass.kt:8: Warning: slack.test.ThisIsDeprecated.ThisIsDeprecated is deprecated; consider using an alternative. [DeprecatedCall]
               ThisIsDeprecated()
               ~~~~~~~~~~~~~~~~~~
           0 errors, 1 warnings
@@ -225,7 +225,7 @@ class DeprecatedAnnotationDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/slack/test/TestClass.kt:8: Warning: This class or method is deprecated; consider using an alternative. [DeprecatedCall]
+          src/slack/test/TestClass.kt:8: Warning: slack.test.ThisIsNotDeprecated.thisIsDeprecated is deprecated; consider using an alternative. [DeprecatedCall]
               ThisIsNotDeprecated().thisIsDeprecated()
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           0 errors, 1 warnings
@@ -237,6 +237,8 @@ class DeprecatedAnnotationDetectorTest : BaseSlackLintTest() {
     """
         package slack.test;
 
+        import java.lang.Deprecated;
+
         @Deprecated()
         class ThisIsDeprecated {
 
@@ -247,8 +249,6 @@ class DeprecatedAnnotationDetectorTest : BaseSlackLintTest() {
   private val NON_DEPRECATED_CLASS = java(
     """
         package slack.test;
-
-        import java.lang.Deprecated;
 
         class ThisIsNotDeprecated {
 

--- a/slack-lint/src/test/java/slack/lint/DeprecatedAnnotationDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/DeprecatedAnnotationDetectorTest.kt
@@ -237,8 +237,6 @@ class DeprecatedAnnotationDetectorTest : BaseSlackLintTest() {
     """
         package slack.test;
 
-        import java.lang.Deprecated;
-
         @Deprecated()
         class ThisIsDeprecated {
 
@@ -249,6 +247,8 @@ class DeprecatedAnnotationDetectorTest : BaseSlackLintTest() {
   private val NON_DEPRECATED_CLASS = java(
     """
         package slack.test;
+        
+        import java.lang.Deprecated;
 
         class ThisIsNotDeprecated {
 


### PR DESCRIPTION
###  Summary

In order to better analyze our deprecated calls in lint reports, it would be helpful if reports identified the referenced deprecation. This PR prefixes the error message with the referenced deprecation when it is available.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
