### PR TITLE
Update lint versions and target latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,13 @@ concurrency:
 
 jobs:
   build:
-    name: ${{ matrix.ci_lint_version }} / JDK ${{ matrix.ci_java_version }} / Kotlin ${{ matrix.ci_kotlin_version }}
+    name: ${{ matrix.ci_lint_version }} / JDK ${{ matrix.ci_java_version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         ci_java_version: ['17']
-        ci_lint_version: ['30.1.2', '30.2.0-beta04', '30.3.0-alpha07']
-        ci_kotlin_version: ['1.6.10']
+        ci_lint_version: ['30.2.0', '30.3.0-beta01', '30.4.0-alpha02']
     env:
       DEP_OVERRIDES: 'true'
       DEP_OVERRIDE_LINT: ${{ matrix.ci_lint_version }}
@@ -46,7 +45,7 @@ jobs:
             ${{ runner.os }}-gradle-${{ matrix.job }}-
 
       - name: Install JDK ${{ matrix.ci_java_version }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.ci_java_version }}
@@ -54,14 +53,14 @@ jobs:
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: spotlessCheck compileKotlin compileTestKotlin
+          arguments: spotlessCheck compileKotlin
 
-      # Test only on current stable because test outputs change wildly between lint versions
+      # Test only on latest because test outputs change wildly between lint versions
       - name: Check
-        if: matrix.ci_lint_version == '30.1.2'
+        if: matrix.ci_lint_version == '30.4.0-alpha02'
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: check --stacktrace -PlintVersion=${{ matrix.ci_lint_version }} -PkotlinVersion=${{ matrix.ci_kotlin_version }}
+          arguments: check --stacktrace
 
       - name: (Fail-only) Bundle the build report
         if: failure()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
-kotlin = "1.6.10"
+kotlin = "1.6.21"
 ktlint = "0.44.0"
 jvmTarget = "1.8"
-lint = "30.1.2"
+lint = "30.4.0-alpha02"
 
 [plugins]
-detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.18.1" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.20.0" }
 dokka = { id = "org.jetbrains.dokka", version = "1.6.10" }
-lint = { id = "com.android.lint", version = "7.1.2" }
-ksp = { id = "com.google.devtools.ksp", version = "1.6.10-1.0.4" }
+lint = { id = "com.android.lint", version = "7.2.0" }
+ksp = { id = "com.google.devtools.ksp", version = "1.6.21-1.0.5" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.19.0" }
 spotless = { id = "com.diffplug.spotless", version = "6.3.0" }
 

--- a/slack-lint/lint-baseline.xml
+++ b/slack-lint/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 7.1.2" type="baseline" client="gradle" dependencies="false" name="AGP (7.1.2)" variant="all" version="7.1.2">
+<issues format="6" by="lint 7.2.0" type="baseline" client="gradle" dependencies="false" name="AGP (7.2.0)" variant="all" version="7.2.0">
 
     <issue
         id="LintImplIdFormat"
@@ -261,7 +261,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/slack/lint/MoshiUsageDetector.kt"
-            line="833"
+            line="841"
             column="9"/>
     </issue>
 
@@ -272,7 +272,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/slack/lint/MoshiUsageDetector.kt"
-            line="838"
+            line="846"
             column="9"/>
     </issue>
 
@@ -571,6 +571,435 @@
             file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
             line="152"
             column="30"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.java.JavaUField is UAST implementation. Consider using one of its corresponding UAST interfaces: `UVariableEx`, `UVariable`, `UDeclaration`, `UAnnotated`, `UDeclarationEx`, `UAnchorOwner`, `UFieldEx`, `UField`"
+        errorLine1="import org.jetbrains.uast.java.JavaUField"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/mocking/AbstractMockDetector.kt"
+            line="33"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.java.JavaUField is UAST implementation. Consider using one of its corresponding UAST interfaces: `UVariableEx`, `UVariable`, `UDeclaration`, `UAnnotated`, `UDeclarationEx`, `UAnchorOwner`, `UFieldEx`, `UField`"
+        errorLine1="        } else if (node is JavaUField &amp;&amp; isMockAnnotated(node)) {"
+        errorLine2="                           ~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/mocking/AbstractMockDetector.kt"
+            line="122"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.java.JavaUCallExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UCallExpressionEx`, `UCallExpression`, `UResolvable`, `UElementWithLocation`"
+        errorLine1="import org.jetbrains.uast.java.JavaUCallExpression"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/ArgInFormattedQuantityStringResDetector.kt"
+            line="31"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.java.JavaUCompositeQualifiedExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UQualifiedReferenceExpression`, `UReferenceExpression`, `UResolvable`"
+        errorLine1="import org.jetbrains.uast.java.JavaUCompositeQualifiedExpression"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/ArgInFormattedQuantityStringResDetector.kt"
+            line="32"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUFunctionCallExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UCallExpression`, `UResolvable`"
+        errorLine1="import org.jetbrains.uast.kotlin.KotlinUFunctionCallExpression"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/ArgInFormattedQuantityStringResDetector.kt"
+            line="33"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUQualifiedReferenceExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UQualifiedReferenceExpression`, `UReferenceExpression`, `UResolvable`"
+        errorLine1="import org.jetbrains.uast.kotlin.KotlinUQualifiedReferenceExpression"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/ArgInFormattedQuantityStringResDetector.kt"
+            line="34"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.java.JavaUCallExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UCallExpressionEx`, `UCallExpression`, `UResolvable`, `UElementWithLocation`"
+        errorLine1="            is JavaUCompositeQualifiedExpression -> checkCall { JavaUCallExpression::class.safeCast(arg.selector) }"
+        errorLine2="                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/ArgInFormattedQuantityStringResDetector.kt"
+            line="65"
+            column="65"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.java.JavaUCompositeQualifiedExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UQualifiedReferenceExpression`, `UReferenceExpression`, `UResolvable`"
+        errorLine1="            is JavaUCompositeQualifiedExpression -> checkCall { JavaUCallExpression::class.safeCast(arg.selector) }"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/ArgInFormattedQuantityStringResDetector.kt"
+            line="65"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.java.JavaUCallExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UCallExpressionEx`, `UCallExpression`, `UResolvable`, `UElementWithLocation`"
+        errorLine1="            is JavaUCallExpression -> checkCall { arg }"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/ArgInFormattedQuantityStringResDetector.kt"
+            line="66"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUFunctionCallExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UCallExpression`, `UResolvable`"
+        errorLine1="            is KotlinUQualifiedReferenceExpression -> checkCall { KotlinUFunctionCallExpression::class.safeCast(arg.selector) }"
+        errorLine2="                                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/ArgInFormattedQuantityStringResDetector.kt"
+            line="67"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUQualifiedReferenceExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UQualifiedReferenceExpression`, `UReferenceExpression`, `UResolvable`"
+        errorLine1="            is KotlinUQualifiedReferenceExpression -> checkCall { KotlinUFunctionCallExpression::class.safeCast(arg.selector) }"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/ArgInFormattedQuantityStringResDetector.kt"
+            line="67"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUFunctionCallExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UCallExpression`, `UResolvable`"
+        errorLine1="            is KotlinUFunctionCallExpression -> checkCall { arg }"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/ArgInFormattedQuantityStringResDetector.kt"
+            line="68"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinReceiverUParameter is UAST implementation. Consider using one of its corresponding UAST interfaces: `UVariableEx`, `UVariable`, `UDeclaration`, `UAnnotated`, `UDeclarationEx`, `UAnchorOwner`, `UParameterEx`, `UParameter`"
+        errorLine1="import org.jetbrains.uast.kotlin.KotlinReceiverUParameter"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/DaggerKotlinIssuesDetector.kt"
+            line="44"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinReceiverUParameter is UAST implementation. Consider using one of its corresponding UAST interfaces: `UVariableEx`, `UVariable`, `UDeclaration`, `UAnnotated`, `UDeclarationEx`, `UAnchorOwner`, `UParameterEx`, `UParameter`"
+        errorLine1="          if (firstParam !is KotlinReceiverUParameter) {"
+        errorLine2="                             ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/DaggerKotlinIssuesDetector.kt"
+            line="131"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUClassLiteralExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UClassLiteralExpression`"
+        errorLine1="import org.jetbrains.uast.kotlin.KotlinUClassLiteralExpression"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/InjectWithUsageDetector.kt"
+            line="29"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUClassLiteralExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UClassLiteralExpression`"
+        errorLine1="            ) as? KotlinUClassLiteralExpression"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/InjectWithUsageDetector.kt"
+            line="63"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUClass is UAST implementation. Consider using one of its corresponding UAST interfaces: `UClass`, `UDeclaration`, `UAnnotated`, `UAnchorOwner`"
+        errorLine1="import org.jetbrains.uast.kotlin.KotlinUClass"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/util/LintUtils.kt"
+            line="45"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUClass is UAST implementation. Consider using one of its corresponding UAST interfaces: `UClass`, `UDeclaration`, `UAnnotated`, `UAnchorOwner`"
+        errorLine1="  if (this is KotlinUClass &amp;&amp; sourcePsi is KtObjectDeclaration &amp;&amp; name == &quot;Companion&quot;) {"
+        errorLine2="              ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/util/LintUtils.kt"
+            line="86"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUClass is UAST implementation. Consider using one of its corresponding UAST interfaces: `UClass`, `UDeclaration`, `UAnnotated`, `UAnchorOwner`"
+        errorLine1="internal fun UClass.isKotlinObject() = this is KotlinUClass &amp;&amp; sourcePsi is KtObjectDeclaration"
+        errorLine2="                                               ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/util/LintUtils.kt"
+            line="99"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUClass is UAST implementation. Consider using one of its corresponding UAST interfaces: `UClass`, `UDeclaration`, `UAnnotated`, `UAnchorOwner`"
+        errorLine1="internal fun UClass.isKotlinTopLevelFacadeClass() = this is KotlinUClass &amp;&amp; javaPsi is KtLightClassForFacade"
+        errorLine2="                                                            ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/util/LintUtils.kt"
+            line="101"
+            column="61"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUClass is UAST implementation. Consider using one of its corresponding UAST interfaces: `UClass`, `UDeclaration`, `UAnnotated`, `UAnchorOwner`"
+        errorLine1="  if (this is KotlinUClass &amp;&amp; evaluator.hasModifier(this, KtTokens.INNER_KEYWORD)) return true"
+        errorLine2="              ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/util/LintUtils.kt"
+            line="111"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUAnnotation is UAST implementation. Consider using one of its corresponding UAST interfaces: `UAnnotationEx`, `UAnnotation`, `UResolvable`, `UAnchorOwner`"
+        errorLine1="import org.jetbrains.uast.kotlin.KotlinUAnnotation"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/MoshiUsageDetector.kt"
+            line="61"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUClassLiteralExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UClassLiteralExpression`"
+        errorLine1="import org.jetbrains.uast.kotlin.KotlinUClassLiteralExpression"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/MoshiUsageDetector.kt"
+            line="62"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUAnnotation is UAST implementation. Consider using one of its corresponding UAST interfaces: `UAnnotationEx`, `UAnnotation`, `UResolvable`, `UAnchorOwner`"
+        errorLine1="                (annotationEntry.toUElement() as KotlinUAnnotation)"
+        errorLine2="                                                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/MoshiUsageDetector.kt"
+            line="365"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUClassLiteralExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UClassLiteralExpression`"
+        errorLine1="      ) as? KotlinUClassLiteralExpression"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/MoshiUsageDetector.kt"
+            line="543"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.java.JavaUCallExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UCallExpressionEx`, `UCallExpression`, `UResolvable`, `UElementWithLocation`"
+        errorLine1="import org.jetbrains.uast.java.JavaUCallExpression"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
+            line="36"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.java.JavaUCompositeQualifiedExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UQualifiedReferenceExpression`, `UReferenceExpression`, `UResolvable`"
+        errorLine1="import org.jetbrains.uast.java.JavaUCompositeQualifiedExpression"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
+            line="37"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUFunctionCallExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UCallExpression`, `UResolvable`"
+        errorLine1="import org.jetbrains.uast.kotlin.KotlinUFunctionCallExpression"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
+            line="38"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUQualifiedReferenceExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UQualifiedReferenceExpression`, `UReferenceExpression`, `UResolvable`"
+        errorLine1="import org.jetbrains.uast.kotlin.KotlinUQualifiedReferenceExpression"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
+            line="39"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUSimpleReferenceExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `USimpleNameReferenceExpression`, `UReferenceExpression`, `UResolvable`"
+        errorLine1="import org.jetbrains.uast.kotlin.KotlinUSimpleReferenceExpression"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
+            line="40"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.psi.UastKotlinPsiVariable is UAST implementation. Consider using one of its corresponding UAST interfaces."
+        errorLine1="import org.jetbrains.uast.kotlin.psi.UastKotlinPsiVariable"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
+            line="41"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.java.JavaUCallExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UCallExpressionEx`, `UCallExpression`, `UResolvable`, `UElementWithLocation`"
+        errorLine1="      is JavaUCompositeQualifiedExpression -> checkCall { JavaUCallExpression::class.safeCast(arg.selector) }"
+        errorLine2="                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
+            line="84"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.java.JavaUCompositeQualifiedExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UQualifiedReferenceExpression`, `UReferenceExpression`, `UResolvable`"
+        errorLine1="      is JavaUCompositeQualifiedExpression -> checkCall { JavaUCallExpression::class.safeCast(arg.selector) }"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
+            line="84"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.java.JavaUCallExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UCallExpressionEx`, `UCallExpression`, `UResolvable`, `UElementWithLocation`"
+        errorLine1="      is JavaUCallExpression -> checkCall { arg }"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
+            line="85"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUFunctionCallExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UCallExpression`, `UResolvable`"
+        errorLine1="      is KotlinUQualifiedReferenceExpression -> checkCall { KotlinUFunctionCallExpression::class.safeCast(arg.selector) }"
+        errorLine2="                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
+            line="86"
+            column="61"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUQualifiedReferenceExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UQualifiedReferenceExpression`, `UReferenceExpression`, `UResolvable`"
+        errorLine1="      is KotlinUQualifiedReferenceExpression -> checkCall { KotlinUFunctionCallExpression::class.safeCast(arg.selector) }"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
+            line="86"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUFunctionCallExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `UCallExpression`, `UResolvable`"
+        errorLine1="      is KotlinUFunctionCallExpression -> checkCall { arg }"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
+            line="87"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.KotlinUSimpleReferenceExpression is UAST implementation. Consider using one of its corresponding UAST interfaces: `UExpression`, `UAnnotated`, `USimpleNameReferenceExpression`, `UReferenceExpression`, `UResolvable`"
+        errorLine1="      is KotlinUSimpleReferenceExpression -> {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
+            line="131"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UastImplementation"
+        message="org.jetbrains.uast.kotlin.psi.UastKotlinPsiVariable is UAST implementation. Consider using one of its corresponding UAST interfaces."
+        errorLine1="          is UastKotlinPsiVariable -> { // The variable reference is local"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/rx/RxSubscribeOnMainDetector.kt"
+            line="137"
+            column="14"/>
     </issue>
 
 </issues>

--- a/slack-lint/src/main/java/slack/lint/SlackIssueRegistry.kt
+++ b/slack-lint/src/main/java/slack/lint/SlackIssueRegistry.kt
@@ -35,6 +35,7 @@ class SlackIssueRegistry : IssueRegistry() {
   override val vendor: Vendor = Vendor(vendorName = "slack", identifier = "slack-lint")
 
   override val api: Int = CURRENT_API
+  override val minApi: Int = 12 // 7.2.0-beta02
 
   @Suppress("SpreadOperator")
   override val issues: List<Issue> = listOf(

--- a/slack-lint/src/main/java/slack/lint/util/LintUtils.kt
+++ b/slack-lint/src/main/java/slack/lint/util/LintUtils.kt
@@ -83,7 +83,7 @@ internal fun PsiClass.implements(
  *  @see [isKotlinObject]
  */
 internal fun UClass.isCompanionObject(evaluator: JavaEvaluator): Boolean {
-  if (this is KotlinUClass && ktClass is KtObjectDeclaration && name == "Companion") {
+  if (this is KotlinUClass && sourcePsi is KtObjectDeclaration && name == "Companion") {
     // best effort until we can update to lint tools 26.6.x. See below
     return true
   }
@@ -96,7 +96,7 @@ internal fun UClass.isCompanionObject(evaluator: JavaEvaluator): Boolean {
  *
  * @see [isCompanionObject]
  */
-internal fun UClass.isKotlinObject() = this is KotlinUClass && ktClass is KtObjectDeclaration
+internal fun UClass.isKotlinObject() = this is KotlinUClass && sourcePsi is KtObjectDeclaration
 
 internal fun UClass.isKotlinTopLevelFacadeClass() = this is KotlinUClass && javaPsi is KtLightClassForFacade
 

--- a/slack-lint/src/test/java/slack/lint/MoshiUsageDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/MoshiUsageDetectorTest.kt
@@ -995,19 +995,19 @@ class MoshiUsageDetectorTest : BaseSlackLintTest() {
       )
       .expectFixDiffs(
         """
-        Fix for src/slack/model/Example.kt line 6: Remove '@JsonClass(generateAdapter = true)':
+        Autofix for src/slack/model/Example.kt line 6: Remove '@JsonClass(generateAdapter = true)':
         @@ -6 +6
         -   @JsonClass(generateAdapter = true)
         +
-        Fix for src/slack/model/Example.kt line 9: Remove '@JsonClass(generateAdapter = true)':
+        Autofix for src/slack/model/Example.kt line 9: Remove '@JsonClass(generateAdapter = true)':
         @@ -9 +9
         -   @JsonClass(generateAdapter = true)
         +
-        Fix for src/slack/model/Example.kt line 12: Remove '@JsonClass(generateAdapter = true)':
+        Autofix for src/slack/model/Example.kt line 12: Remove '@JsonClass(generateAdapter = true)':
         @@ -12 +12
         -   @JsonClass(generateAdapter = true)
         +
-        Fix for src/slack/model/Example.kt line 15: Remove '@JsonClass(generateAdapter = true)':
+        Autofix for src/slack/model/Example.kt line 15: Remove '@JsonClass(generateAdapter = true)':
         @@ -15 +15
         -   @JsonClass(generateAdapter = true)
         +


### PR DESCRIPTION
This updates our project to the latest lint APIs and also begins targeting building against latest. This should fix compatibility on newer studio versions + ease updates in the future by targeting latest (even while we still support lower versions).