### PR TITLE
Implement DoNotExposeEitherNetInRepositoriesDetector

### DIFF
--- a/slack-lint/src/main/java/slack/lint/SlackIssueRegistry.kt
+++ b/slack-lint/src/main/java/slack/lint/SlackIssueRegistry.kt
@@ -20,6 +20,7 @@ import com.android.tools.lint.client.api.Vendor
 import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
 import com.google.auto.service.AutoService
+import slack.lint.eithernet.DoNotExposeEitherNetInRepositoriesDetector
 import slack.lint.inclusive.InclusiveNamingChecker
 import slack.lint.mocking.AutoValueMockDetector
 import slack.lint.mocking.DataClassMockDetector
@@ -65,5 +66,6 @@ class SlackIssueRegistry : IssueRegistry() {
     RetrofitUsageDetector.ISSUE,
     RestrictCallsToDetector.ISSUE,
     SpanMarkPointMissingMaskDetector.ISSUE,
+    DoNotExposeEitherNetInRepositoriesDetector.ISSUE,
   )
 }

--- a/slack-lint/src/main/java/slack/lint/eithernet/DoNotExposeEitherNetInRepositoriesDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/eithernet/DoNotExposeEitherNetInRepositoriesDetector.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint.eithernet
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Location
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.isJava
+import com.intellij.psi.PsiModifierListOwner
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtModifierListOwner
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UField
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.UTypeReferenceExpression
+import org.jetbrains.uast.getContainingUClass
+import slack.lint.util.sourceImplementation
+
+private const val EITHERNET_PACKAGE = "com.slack.eithernet"
+
+/** Reports an error when returning EitherNet types directly in public repository APIs. */
+class DoNotExposeEitherNetInRepositoriesDetector : Detector(), SourceCodeScanner {
+
+  override fun getApplicableUastTypes(): List<Class<out UElement>> =
+    listOf(UMethod::class.java, UField::class.java)
+
+  override fun createUastHandler(context: JavaContext) =
+    object : UElementHandler() {
+      val isJava = isJava(context.psiFile)
+
+      override fun visitMethod(node: UMethod) {
+        if (node.sourcePsi is KtProperty) return // Handled by visitField
+        check(
+          node.isPublic,
+          { node.isRepositoryMember },
+          { node.returnTypeReference.isEitherNetType },
+          { context.getLocation(node) }
+        )
+      }
+
+      override fun visitField(node: UField) {
+        check(
+          node.isPublic,
+          { node.isRepositoryMember },
+          { node.typeReference.isEitherNetType },
+          { context.getLocation(node) }
+        )
+      }
+
+      private val UElement.isPublic: Boolean
+        get() {
+          if (isJava && this is PsiModifierListOwner) {
+            if (modifierList?.hasExplicitModifier("public") == true) return true
+          }
+          if (sourcePsi is KtModifierListOwner) {
+            val ktModifierListOwner = sourcePsi as KtModifierListOwner
+            val visibility = ktModifierListOwner.visibilityModifierTypeOrDefault()
+            if (visibility == KtTokens.PUBLIC_KEYWORD) return true
+          }
+          return getContainingUClass()?.isInterface == true
+        }
+
+      private fun check(
+        isPublic: Boolean,
+        isRepositoryMember: () -> Boolean,
+        isEitherNetType: () -> Boolean,
+        location: () -> Location
+      ) {
+        if (!isPublic) return
+        if (!isRepositoryMember()) return
+        if (isEitherNetType()) {
+          context.report(
+            issue = ISSUE,
+            location = location(),
+            message = "Repository APIs should not expose EitherNet types directly."
+          )
+        }
+      }
+
+      private val UElement.isRepositoryMember: Boolean
+        get() {
+          val containingClass = getContainingUClass() ?: return false
+          return containingClass.name?.endsWith("Repository") == true
+        }
+
+      private val UTypeReferenceExpression?.isEitherNetType: Boolean
+        get() {
+          return this?.getQualifiedName()?.startsWith(EITHERNET_PACKAGE) == true
+        }
+    }
+
+  companion object {
+    private fun Implementation.toIssue(): Issue {
+      return Issue.create(
+        id = "DoNotExposeEitherNetInRepositories",
+        briefDescription = "Repository APIs should not expose EitherNet types directly.",
+        explanation =
+        "EitherNet (and networking in general) should be an implementation detail of the repository layer.",
+        category = Category.CORRECTNESS,
+        priority = 0,
+        severity = Severity.ERROR,
+        implementation = this
+      )
+    }
+
+    val ISSUE: Issue = sourceImplementation<DoNotExposeEitherNetInRepositoriesDetector>().toIssue()
+  }
+}

--- a/slack-lint/src/test/java/slack/lint/eithernet/DoNotExposeEitherNetInRepositoriesDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/eithernet/DoNotExposeEitherNetInRepositoriesDetectorTest.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint.eithernet
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest.kotlin
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+
+private val API_RESULT =
+  kotlin(
+    """
+  package com.slack.eithernet
+
+  interface ApiResult<out T : Any, out E : Any>
+"""
+  )
+    .indented()
+
+class DoNotExposeEitherNetInRepositoriesDetectorTest : BaseSlackLintTest() {
+  override fun getDetector() = DoNotExposeEitherNetInRepositoriesDetector()
+
+  override fun getIssues() = listOf(DoNotExposeEitherNetInRepositoriesDetector.ISSUE)
+
+  @Test
+  fun javaTests() {
+    lint()
+      .files(
+        API_RESULT,
+        java(
+          """
+        package test;
+
+        import com.slack.eithernet.ApiResult;
+
+        interface MyRepository {
+          // Bad
+
+          ApiResult<String, Exception> getResult();
+
+          // Good
+
+          String getString();
+        }
+      """
+        )
+          .indented(),
+
+        // Non-interface version
+        java(
+          """
+        package test;
+
+        import com.slack.eithernet.ApiResult;
+
+        abstract class MyClassRepository {
+          // Bad
+
+          public abstract ApiResult<String, Exception> getResultPublic();
+          public ApiResult<String, Exception> resultField = null;
+
+          // Good
+
+          ApiResult<String, Exception> resultFieldPackagePrivate = null;
+          private final ApiResult<String, Exception> resultFieldPrivate = null;
+          protected ApiResult<String, Exception> resultFieldProtected = null;
+          abstract ApiResult<String, Exception> getResultPackagePrivate();
+          private ApiResult<String, Exception> getResultPrivate();
+          private ApiResult<String, Exception> getResultProtected();
+          public abstract String getString();
+        }
+      """
+        )
+          .indented(),
+      )
+      .run()
+      .expect(
+        """
+        src/test/MyClassRepository.java:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          public abstract ApiResult<String, Exception> getResultPublic();
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test/MyClassRepository.java:9: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          public ApiResult<String, Exception> resultField = null;
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test/MyRepository.java:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          ApiResult<String, Exception> getResult();
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        3 errors, 0 warnings
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun kotlinTests() {
+    lint()
+      .files(
+        API_RESULT,
+        kotlin(
+          """
+        package test
+
+        import com.slack.eithernet.ApiResult
+
+        interface MyRepository {
+          // Bad
+
+          fun getResult(): ApiResult<String, Exception>
+          val resultVal: ApiResult<String, Exception>
+
+          // Good
+
+          fun getString(): String
+          val stringValue: String
+        }
+      """
+        )
+          .indented(),
+
+        // Non-interface version
+        kotlin(
+          """
+        package test
+
+        import com.slack.eithernet.ApiResult
+
+        abstract class MyClassRepository {
+          // Bad
+
+          abstract fun getResultPublic(): ApiResult<String, Exception>
+          val resultProperty: ApiResult<String, Exception>? = null
+
+          // Good
+
+          internal val resultPropertyInternal: ApiResult<String, Exception>? = null
+          private val resultPropertyPrivate: ApiResult<String, Exception>? = null
+          protected val resultPropertyProtected: ApiResult<String, Exception>? = null
+          internal abstract fun getResultInternal(): ApiResult<String, Exception>
+          private fun getResultPrivate(): ApiResult<String, Exception>
+          private fun getResultProtected(): ApiResult<String, Exception>
+          abstract fun getString(): String
+        }
+      """
+        )
+          .indented(),
+      )
+      .run()
+      .expect(
+        """
+        src/test/MyClassRepository.kt:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          abstract fun getResultPublic(): ApiResult<String, Exception>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test/MyClassRepository.kt:9: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          val resultProperty: ApiResult<String, Exception>? = null
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test/MyRepository.kt:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          fun getResult(): ApiResult<String, Exception>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        3 errors, 0 warnings
+        """.trimIndent()
+      )
+  }
+}


### PR DESCRIPTION
We don't want folks to expose these types directly in the repository layer, it creates awkward situations where the UI suddenly has to know what to do about network failures as a state.