### PR TITLE
Fix support for suspend functions in EitherNet and Retrofit lints

### DIFF
--- a/slack-lint/src/main/java/slack/lint/eithernet/DoNotExposeEitherNetInRepositoriesDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/eithernet/DoNotExposeEitherNetInRepositoriesDetector.kt
@@ -26,6 +26,8 @@ import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.android.tools.lint.detector.api.isJava
 import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.PsiType
+import com.intellij.psi.util.PsiTypesUtil
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtModifierListOwner
 import org.jetbrains.kotlin.psi.KtProperty
@@ -33,8 +35,8 @@ import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UField
 import org.jetbrains.uast.UMethod
-import org.jetbrains.uast.UTypeReferenceExpression
 import org.jetbrains.uast.getContainingUClass
+import slack.lint.util.safeReturnType
 import slack.lint.util.sourceImplementation
 
 private const val EITHERNET_PACKAGE = "com.slack.eithernet"
@@ -54,7 +56,7 @@ class DoNotExposeEitherNetInRepositoriesDetector : Detector(), SourceCodeScanner
         check(
           node.isPublic,
           { node.isRepositoryMember },
-          { node.returnTypeReference.isEitherNetType },
+          { node.safeReturnType(context).isEitherNetType },
           { context.getLocation(node) }
         )
       }
@@ -63,7 +65,7 @@ class DoNotExposeEitherNetInRepositoriesDetector : Detector(), SourceCodeScanner
         check(
           node.isPublic,
           { node.isRepositoryMember },
-          { node.typeReference.isEitherNetType },
+          { node.type.isEitherNetType },
           { context.getLocation(node) }
         )
       }
@@ -104,9 +106,9 @@ class DoNotExposeEitherNetInRepositoriesDetector : Detector(), SourceCodeScanner
           return containingClass.name?.endsWith("Repository") == true
         }
 
-      private val UTypeReferenceExpression?.isEitherNetType: Boolean
+      private val PsiType?.isEitherNetType: Boolean
         get() {
-          return this?.getQualifiedName()?.startsWith(EITHERNET_PACKAGE) == true
+          return PsiTypesUtil.getPsiClass(this)?.qualifiedName?.startsWith(EITHERNET_PACKAGE) == true
         }
     }
 

--- a/slack-lint/src/main/java/slack/lint/retrofit/RetrofitUsageDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/retrofit/RetrofitUsageDetector.kt
@@ -29,6 +29,7 @@ import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.sourcePsiElement
 import slack.lint.util.removeNode
+import slack.lint.util.safeReturnType
 import slack.lint.util.sourceImplementation
 
 /**
@@ -51,8 +52,8 @@ class RetrofitUsageDetector : Detector(), SourceCodeScanner {
           .firstOrNull()
           ?: return
 
-        val returnType = node.returnTypeReference?.type
-        if (returnType == null || returnType == PsiType.VOID) {
+        val returnType = node.safeReturnType(context)
+        if (returnType == null || returnType == PsiType.VOID || returnType.canonicalText == "kotlin.Unit") {
           node.report(
             "Retrofit endpoints should return something other than Unit/void.",
             context.getNameLocation(node)

--- a/slack-lint/src/main/java/slack/lint/util/LintUtils.kt
+++ b/slack-lint/src/main/java/slack/lint/util/LintUtils.kt
@@ -38,6 +38,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiType
 import com.intellij.psi.PsiWildcardType
 import org.jetbrains.kotlin.asJava.classes.KtLightClassForFacade
+import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.uast.UClass
@@ -47,7 +48,6 @@ import org.jetbrains.uast.UQualifiedReferenceExpression
 import org.jetbrains.uast.UReferenceExpression
 import org.jetbrains.uast.USimpleNameReferenceExpression
 import org.jetbrains.uast.kotlin.KotlinUClass
-import org.jetbrains.uast.kotlin.isKotlin
 import org.jetbrains.uast.tryResolve
 import java.util.EnumSet
 
@@ -327,7 +327,7 @@ internal fun UExpression.resolveQualifiedNameOrNull(): String? {
  * ```
 */
 internal fun UMethod.safeReturnType(context: JavaContext): PsiType? {
-  if (isKotlin(this) && context.evaluator.isSuspend(this)) {
+  if (language == KotlinLanguage.INSTANCE && context.evaluator.isSuspend(this)) {
     val classReference = parameterList.parameters.lastOrNull()?.type as? PsiClassType ?: return null
     val wildcard = classReference.parameters.singleOrNull() as? PsiWildcardType ?: return null
     return wildcard.bound

--- a/slack-lint/src/main/java/slack/lint/util/LintUtils.kt
+++ b/slack-lint/src/main/java/slack/lint/util/LintUtils.kt
@@ -33,16 +33,21 @@ import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.android.tools.lint.detector.api.UastLintUtils
 import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiType
+import com.intellij.psi.PsiWildcardType
 import org.jetbrains.kotlin.asJava.classes.KtLightClassForFacade
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.uast.UClass
 import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.UQualifiedReferenceExpression
 import org.jetbrains.uast.UReferenceExpression
 import org.jetbrains.uast.USimpleNameReferenceExpression
 import org.jetbrains.uast.kotlin.KotlinUClass
+import org.jetbrains.uast.kotlin.isKotlin
 import org.jetbrains.uast.tryResolve
 import java.util.EnumSet
 
@@ -302,5 +307,31 @@ internal fun UExpression.unwrapSimpleNameReferenceExpression(): USimpleNameRefer
 internal fun UExpression.resolveQualifiedNameOrNull(): String? {
   return (this as? UReferenceExpression)?.referenceNameElement?.uastParent?.tryResolve()?.let {
     UastLintUtils.getQualifiedName(it)
+  }
+}
+
+/**
+ * Collects the return type of this [UMethod] in a suspend-safe way.
+ *
+ * For coroutines, the suspend methods return context rather than the source-declared return type,
+ * which is encoded in a continuation parameter at the end of the parameter list.
+ *
+ * For example, the following snippet:
+ * ```
+ * suspend fun foo(): String
+ * ```
+ *
+ * Will appear like so to lint:
+ * ```
+ * Object foo(Continuation<? super String> continuation)
+ * ```
+*/
+internal fun UMethod.safeReturnType(context: JavaContext): PsiType? {
+  if (isKotlin(this) && context.evaluator.isSuspend(this)) {
+    val classReference = parameterList.parameters.lastOrNull()?.type as? PsiClassType ?: return null
+    val wildcard = classReference.parameters.singleOrNull() as? PsiWildcardType ?: return null
+    return wildcard.bound
+  } else {
+    return returnType
   }
 }

--- a/slack-lint/src/test/java/slack/lint/eithernet/DoNotExposeEitherNetInRepositoriesDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/eithernet/DoNotExposeEitherNetInRepositoriesDetectorTest.kt
@@ -88,19 +88,16 @@ class DoNotExposeEitherNetInRepositoriesDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/test/MyClassRepository.kt:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
-          abstract fun getResultPublic(): ApiResult<String, Exception>
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        src/test/MyClassRepository.kt:9: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
-          val resultProperty: ApiResult<String, Exception>? = null
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        src/test/MyRepository.kt:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
-          fun getResult(): ApiResult<String, Exception>
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        src/test/MyRepository.kt:9: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
-          suspend fun getResultSuspended(): ApiResult<String, Exception>
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        4 errors, 0 warnings
+        src/test/MyClassRepository.java:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          public abstract ApiResult<String, Exception> getResultPublic();
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test/MyClassRepository.java:9: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          public ApiResult<String, Exception> resultField = null;
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test/MyRepository.java:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          ApiResult<String, Exception> getResult();
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        3 errors, 0 warnings
         """.trimIndent()
       )
   }
@@ -172,7 +169,10 @@ class DoNotExposeEitherNetInRepositoriesDetectorTest : BaseSlackLintTest() {
         src/test/MyRepository.kt:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
           fun getResult(): ApiResult<String, Exception>
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        3 errors, 0 warnings
+        src/test/MyRepository.kt:9: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          suspend fun getResultSuspended(): ApiResult<String, Exception>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        4 errors, 0 warnings
         """.trimIndent()
       )
   }

--- a/slack-lint/src/test/java/slack/lint/eithernet/DoNotExposeEitherNetInRepositoriesDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/eithernet/DoNotExposeEitherNetInRepositoriesDetectorTest.kt
@@ -88,16 +88,19 @@ class DoNotExposeEitherNetInRepositoriesDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/test/MyClassRepository.java:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
-          public abstract ApiResult<String, Exception> getResultPublic();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        src/test/MyClassRepository.java:9: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
-          public ApiResult<String, Exception> resultField = null;
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        src/test/MyRepository.java:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
-          ApiResult<String, Exception> getResult();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        3 errors, 0 warnings
+        src/test/MyClassRepository.kt:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          abstract fun getResultPublic(): ApiResult<String, Exception>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test/MyClassRepository.kt:9: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          val resultProperty: ApiResult<String, Exception>? = null
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test/MyRepository.kt:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          fun getResult(): ApiResult<String, Exception>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test/MyRepository.kt:9: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          suspend fun getResultSuspended(): ApiResult<String, Exception>
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        4 errors, 0 warnings
         """.trimIndent()
       )
   }
@@ -117,11 +120,13 @@ class DoNotExposeEitherNetInRepositoriesDetectorTest : BaseSlackLintTest() {
           // Bad
 
           fun getResult(): ApiResult<String, Exception>
+          suspend fun getResultSuspended(): ApiResult<String, Exception>
           val resultVal: ApiResult<String, Exception>
 
           // Good
 
           fun getString(): String
+          suspend fun getStringSuspended(): String
           val stringValue: String
         }
       """
@@ -168,6 +173,43 @@ class DoNotExposeEitherNetInRepositoriesDetectorTest : BaseSlackLintTest() {
           fun getResult(): ApiResult<String, Exception>
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         3 errors, 0 warnings
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun regressionTest() {
+    lint()
+      .files(
+        API_RESULT,
+        kotlin(
+          """
+        package test
+
+        import com.slack.eithernet.ApiResult
+
+        interface StuffRepository {
+
+          suspend fun fetchStuff(): ApiResult<String, String>
+
+          suspend fun setStuff(
+            discoverability: String
+          ): ApiResult<Unit, String>
+        }
+      """
+        )
+          .indented(),
+      )
+      .run()
+      .expect(
+        """
+          src/test/StuffRepository.kt:7: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+            suspend fun fetchStuff(): ApiResult<String, String>
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          src/test/StuffRepository.kt:9: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+            suspend fun setStuff(
+            ^
+          2 errors, 0 warnings
         """.trimIndent()
       )
   }

--- a/slack-lint/src/test/java/slack/lint/retrofit/RetrofitUsageDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/retrofit/RetrofitUsageDetectorTest.kt
@@ -58,7 +58,8 @@ class RetrofitUsageDetectorTest : BaseSlackLintTest() {
               fun correct(@Field("hi") input: String): String
             }
           """
-        ).indented()
+        )
+          .indented()
       )
       .run()
       .expect(
@@ -117,7 +118,8 @@ class RetrofitUsageDetectorTest : BaseSlackLintTest() {
               fun correct(@Body input: String): String
             }
           """
-        ).indented()
+        )
+          .indented()
       )
       .run()
       .expect(
@@ -152,10 +154,14 @@ class RetrofitUsageDetectorTest : BaseSlackLintTest() {
               fun unitMethod()
 
               @GET("/")
+              suspend fun suspendUnitMethod()
+
+              @GET("/")
               fun unitMethodExplicit(): Unit
             }
           """
-        ).indented()
+        )
+          .indented()
       )
       .run()
       .expect(
@@ -164,9 +170,12 @@ class RetrofitUsageDetectorTest : BaseSlackLintTest() {
           fun unitMethod()
               ~~~~~~~~~~
         src/test/Example.kt:10: Error: Retrofit endpoints should return something other than Unit/void. [RetrofitUsage]
+          suspend fun suspendUnitMethod()
+                      ~~~~~~~~~~~~~~~~~
+        src/test/Example.kt:13: Error: Retrofit endpoints should return something other than Unit/void. [RetrofitUsage]
           fun unitMethodExplicit(): Unit
               ~~~~~~~~~~~~~~~~~~
-        2 errors, 0 warnings
+        3 errors, 0 warnings
         """.trimIndent()
       )
   }


### PR DESCRIPTION
These have to be handled in a special way in order to correctly read their return types