### PR TITLE
Improve error location for eithernet lints

### DIFF
--- a/slack-lint/src/main/java/slack/lint/eithernet/DoNotExposeEitherNetInRepositoriesDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/eithernet/DoNotExposeEitherNetInRepositoriesDetector.kt
@@ -57,7 +57,7 @@ class DoNotExposeEitherNetInRepositoriesDetector : Detector(), SourceCodeScanner
           node.isPublic,
           { node.isRepositoryMember },
           { node.safeReturnType(context).isEitherNetType },
-          { context.getLocation(node) }
+          { context.getLocation(node.returnTypeReference ?: node) }
         )
       }
 
@@ -66,7 +66,7 @@ class DoNotExposeEitherNetInRepositoriesDetector : Detector(), SourceCodeScanner
           node.isPublic,
           { node.isRepositoryMember },
           { node.type.isEitherNetType },
-          { context.getLocation(node) }
+          { context.getLocation(node.typeReference ?: node) }
         )
       }
 

--- a/slack-lint/src/test/java/slack/lint/eithernet/DoNotExposeEitherNetInRepositoriesDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/eithernet/DoNotExposeEitherNetInRepositoriesDetectorTest.kt
@@ -90,13 +90,13 @@ class DoNotExposeEitherNetInRepositoriesDetectorTest : BaseSlackLintTest() {
         """
         src/test/MyClassRepository.java:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
           public abstract ApiResult<String, Exception> getResultPublic();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         src/test/MyClassRepository.java:9: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
           public ApiResult<String, Exception> resultField = null;
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         src/test/MyRepository.java:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
           ApiResult<String, Exception> getResult();
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         3 errors, 0 warnings
         """.trimIndent()
       )
@@ -141,7 +141,9 @@ class DoNotExposeEitherNetInRepositoriesDetectorTest : BaseSlackLintTest() {
           // Bad
 
           abstract fun getResultPublic(): ApiResult<String, Exception>
+          fun typeLessFunction() = getResultPublic()
           val resultProperty: ApiResult<String, Exception>? = null
+          val typeLessProperty get() = resultProperty
 
           // Good
 
@@ -162,17 +164,23 @@ class DoNotExposeEitherNetInRepositoriesDetectorTest : BaseSlackLintTest() {
         """
         src/test/MyClassRepository.kt:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
           abstract fun getResultPublic(): ApiResult<String, Exception>
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         src/test/MyClassRepository.kt:9: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          fun typeLessFunction() = getResultPublic()
+              ~~~~~~~~~~~~~~~~
+        src/test/MyClassRepository.kt:10: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
           val resultProperty: ApiResult<String, Exception>? = null
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test/MyClassRepository.kt:11: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+          val typeLessProperty get() = resultProperty
+              ~~~~~~~~~~~~~~~~
         src/test/MyRepository.kt:8: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
           fun getResult(): ApiResult<String, Exception>
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         src/test/MyRepository.kt:9: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
           suspend fun getResultSuspended(): ApiResult<String, Exception>
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        4 errors, 0 warnings
+                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        6 errors, 0 warnings
         """.trimIndent()
       )
   }
@@ -205,10 +213,10 @@ class DoNotExposeEitherNetInRepositoriesDetectorTest : BaseSlackLintTest() {
         """
           src/test/StuffRepository.kt:7: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
             suspend fun fetchStuff(): ApiResult<String, String>
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          src/test/StuffRepository.kt:9: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
-            suspend fun setStuff(
-            ^
+                                      ~~~~~~~~~~~~~~~~~~~~~~~~~
+          src/test/StuffRepository.kt:11: Error: Repository APIs should not expose EitherNet types directly. [DoNotExposeEitherNetInRepositories]
+            ): ApiResult<Unit, String>
+               ~~~~~~~~~~~~~~~~~~~~~~~
           2 errors, 0 warnings
         """.trimIndent()
       )


### PR DESCRIPTION
This highlights the specific type when possible as the offending issue, rather than the whole line.