### PR TITLE
Add non-transitive R class lints

### DIFF
--- a/slack-lint/src/main/java/slack/lint/SlackIssueRegistry.kt
+++ b/slack-lint/src/main/java/slack/lint/SlackIssueRegistry.kt
@@ -26,6 +26,9 @@ import slack.lint.mocking.AutoValueMockDetector
 import slack.lint.mocking.DataClassMockDetector
 import slack.lint.mocking.DoNotMockMockDetector
 import slack.lint.mocking.ErrorProneDoNotMockDetector
+import slack.lint.resources.FullyQualifiedResourceDetector
+import slack.lint.resources.MissingResourceImportAliasDetector
+import slack.lint.resources.WrongResourceImportAliasDetector
 import slack.lint.retrofit.RetrofitUsageDetector
 import slack.lint.rx.RxSubscribeOnMainDetector
 import slack.lint.text.SpanMarkPointMissingMaskDetector
@@ -67,5 +70,8 @@ class SlackIssueRegistry : IssueRegistry() {
     RestrictCallsToDetector.ISSUE,
     SpanMarkPointMissingMaskDetector.ISSUE,
     DoNotExposeEitherNetInRepositoriesDetector.ISSUE,
+    FullyQualifiedResourceDetector.ISSUE,
+    MissingResourceImportAliasDetector.ISSUE,
+    WrongResourceImportAliasDetector.ISSUE,
   )
 }

--- a/slack-lint/src/main/java/slack/lint/resources/FullyQualifiedResourceDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/FullyQualifiedResourceDetector.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint.resources
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.isKotlin
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UQualifiedReferenceExpression
+import slack.lint.resources.model.IMPORT_ALIASES
+import slack.lint.util.sourceImplementation
+
+private const val FQN_ANDROID_R = "android.R"
+
+/** Reports an error when an R class is referenced using its fully qualified name. */
+class FullyQualifiedResourceDetector : Detector(), SourceCodeScanner {
+
+  override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(UQualifiedReferenceExpression::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    return object : UElementHandler() {
+
+      override fun visitQualifiedReferenceExpression(node: UQualifiedReferenceExpression) {
+        // Import alias is a Kotlin feature.
+        if (!isKotlin(node.lang)) return
+
+        val qualifier = node.receiver.asSourceString()
+        if (qualifier.endsWith(".R") && qualifier != FQN_ANDROID_R) {
+          val alias = IMPORT_ALIASES[qualifier]
+
+          context.report(
+            ISSUE,
+            context.getNameLocation(node.receiver),
+            if (alias != null) "Please use $alias as an import alias instead" else "Please use an import alias instead",
+            quickfixData = createLintFix(alias, node, qualifier)
+          )
+        }
+      }
+
+      private fun createLintFix(alias: String?, node: UQualifiedReferenceExpression, qualifier: String): LintFix? {
+        return if (alias != null) {
+          val fixes = mutableListOf(
+            fix()
+              .replace()
+              .range(context.getLocation(node.receiver))
+              .with(alias)
+              .build()
+          )
+
+          // Alternative to ReplaceStringBuilder#imports since that one didn't work here.
+          addImportIfMissing(qualifier, alias, fixes)
+
+          fix().name("Replace import alias").composite(
+            *fixes.reversed().toTypedArray()
+          ).autoFix()
+        } else {
+          null
+        }
+      }
+
+      private fun addImportIfMissing(qualifier: String, alias: String, issues: MutableList<LintFix>) {
+        context.uastFile?.imports?.let { imports ->
+          val importIsMissing = !imports.any {
+            val importDirective = it.sourcePsi as? KtImportDirective
+
+            val importedFqNameString = importDirective?.importedFqName?.asString()
+            qualifier == importedFqNameString && alias == importDirective.aliasName
+          }
+
+          if (importIsMissing) {
+            if (imports.isNotEmpty()) {
+              val lastImport = imports.last().sourcePsi as? KtImportDirective
+              addImportAfterLastImport(lastImport, qualifier, alias, issues)
+            } else {
+              addImportAfterPackageName(qualifier, alias, issues)
+            }
+          }
+        }
+      }
+
+      private fun addImportAfterLastImport(lastImport: KtImportDirective?, qualifier: String, alias: String, issues: MutableList<LintFix>) {
+        if (lastImport != null) {
+          issues.add(
+            fix()
+              .replace()
+              .range(context.getLocation(lastImport))
+              .with(lastImport.text + System.lineSeparator() + "import $qualifier as $alias")
+              .build()
+          )
+        }
+      }
+
+      private fun addImportAfterPackageName(qualifier: String, alias: String, issues: MutableList<LintFix>) {
+        (context.psiFile as? KtFile)?.packageDirective ?.let { packageDirective ->
+          issues.add(
+            fix()
+              .replace()
+              .range(context.getLocation(packageDirective))
+              .with(packageDirective.text + System.lineSeparator() + System.lineSeparator() + "import $qualifier as $alias")
+              .build()
+          )
+        }
+      }
+    }
+  }
+
+  companion object {
+    val ISSUE: Issue =
+      Issue.create(
+        "FullyQualifiedResource",
+        "Resources should use an import alias instead of being fully qualified.",
+        "Resources should use an import alias instead of being fully qualified. For example: \n" +
+          "import slack.l10n.R as L10nR\n" +
+          "...\n" +
+          "...getString(L10nR.string.app_name)",
+        Category.CORRECTNESS,
+        6,
+        Severity.ERROR,
+        sourceImplementation<FullyQualifiedResourceDetector>()
+      )
+  }
+}

--- a/slack-lint/src/main/java/slack/lint/resources/FullyQualifiedResourceDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/FullyQualifiedResourceDetector.kt
@@ -29,18 +29,19 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UQualifiedReferenceExpression
-import slack.lint.resources.ImportAliasesLoader.importAliases
+import slack.lint.resources.ImportAliasesLoader.IMPORT_ALIASES
 import slack.lint.util.sourceImplementation
 
 private const val FQN_ANDROID_R = "android.R"
 
 /** Reports an error when an R class is referenced using its fully qualified name. */
 class FullyQualifiedResourceDetector : Detector(), SourceCodeScanner {
+  private lateinit var importAliases: Map<String, String>
 
   override fun beforeCheckRootProject(context: Context) {
     super.beforeCheckRootProject(context)
 
-    ImportAliasesLoader.loadImportAliases(context)
+    importAliases = ImportAliasesLoader.loadImportAliases(context)
   }
 
   override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(UQualifiedReferenceExpression::class.java)
@@ -145,6 +146,6 @@ class FullyQualifiedResourceDetector : Detector(), SourceCodeScanner {
         6,
         Severity.ERROR,
         sourceImplementation<FullyQualifiedResourceDetector>()
-      )
+      ).setOptions(listOf(IMPORT_ALIASES))
   }
 }

--- a/slack-lint/src/main/java/slack/lint/resources/FullyQualifiedResourceDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/FullyQualifiedResourceDetector.kt
@@ -52,7 +52,7 @@ class FullyQualifiedResourceDetector : Detector(), SourceCodeScanner {
           context.report(
             ISSUE,
             context.getNameLocation(node.receiver),
-            if (alias != null) "Please use $alias as an import alias instead" else "Please use an import alias instead",
+            if (alias != null) "Use $alias as an import alias instead" else "Use an import alias instead",
             quickfixData = createLintFix(alias, node, qualifier)
           )
         }

--- a/slack-lint/src/main/java/slack/lint/resources/ImportAliasesLoader.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/ImportAliasesLoader.kt
@@ -1,0 +1,82 @@
+package slack.lint.resources
+
+import com.android.tools.lint.detector.api.Context
+import java.io.File
+import java.io.StringReader
+import java.util.Properties
+
+object ImportAliasesLoader {
+    const val PROPERTY_FILE = "gradle.properties"
+    const val IMPORT_ALIASES_PROPERTY = "nonTransitiveRClass.importAliases"
+
+    private const val TOP_LEVEL_FILENAME = "settings.gradle"
+
+    // Caches the import aliases to improve performance.
+    var importAliases = emptyMap<String, String>()
+        private set
+
+    /**
+     * Loads the import aliases from the root [PROPERTY_FILE].
+     * If it can't find it, it defaults to the local [PROPERTY_FILE].
+     */
+    fun loadImportAliases(context: Context) {
+        // Project#getPropertyFiles returns the current module's PROPERTY_FILE file.
+        // To avoid having to define IMPORT_ALIASES_PROPERTY in every module's PROPERTY_FILE,
+        // this loads it from the root folder's PROPERTY_FILE.
+
+        if (importAliases.isEmpty()) {
+            val root: File? = findRoot(context)
+
+            File(root, PROPERTY_FILE).run {
+                if (this.exists()) {
+                    val aliasesProperty = getProperty(context, IMPORT_ALIASES_PROPERTY)
+                    if (aliasesProperty != null)
+                        loadFromProperty(aliasesProperty)
+                    else
+                        loadFromLocalPropertyFile(context)
+
+                } else {
+                    loadFromLocalPropertyFile(context)
+                }
+            }
+        }
+    }
+
+    /**
+     * Finds the root folder containing the [TOP_LEVEL_FILENAME] file.
+     */
+    private fun findRoot(context: Context): File? {
+        var file: File? = context.project.dir
+        while (file != null && file.listFiles { _, name ->
+                    name.contains(TOP_LEVEL_FILENAME)
+                }?.isEmpty() == true) {
+            file = file.parentFile
+        }
+        return file
+    }
+
+    private fun File.getProperty(context: Context, key:String): String? {
+        val content = StringReader(context.client.readFile(this).toString())
+        val props = Properties()
+        props.load(content)
+        return props.getProperty(key)
+    }
+
+    private fun loadFromProperty(aliasesProperty: String?) {
+        aliasesProperty?.splitToSequence(",")
+                .orEmpty()
+                .map(String::trim)
+                .filter(String::isNotBlank)
+                .map {
+                    val (packageName, alias) = it.split(" as ")
+                    packageName.trim() to alias.trim()
+                }.toMap().let { importAliases = it }
+    }
+
+
+    private fun loadFromLocalPropertyFile(context: Context) {
+        context.project.propertyFiles.find { it.name == PROPERTY_FILE }?.run {
+            loadFromProperty(getProperty(context, IMPORT_ALIASES_PROPERTY))
+        }
+    }
+}

--- a/slack-lint/src/main/java/slack/lint/resources/ImportAliasesLoader.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/ImportAliasesLoader.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package slack.lint.resources
 
 import com.android.tools.lint.detector.api.Context
@@ -6,77 +21,76 @@ import java.io.StringReader
 import java.util.Properties
 
 object ImportAliasesLoader {
-    const val PROPERTY_FILE = "gradle.properties"
-    const val IMPORT_ALIASES_PROPERTY = "nonTransitiveRClass.importAliases"
+  const val PROPERTY_FILE = "gradle.properties"
+  const val IMPORT_ALIASES_PROPERTY = "nonTransitiveRClass.importAliases"
 
-    private const val TOP_LEVEL_FILENAME = "settings.gradle"
+  private const val TOP_LEVEL_FILENAME = "settings.gradle"
 
-    // Caches the import aliases to improve performance.
-    var importAliases = emptyMap<String, String>()
-        private set
+  // Caches the import aliases to improve performance.
+  var importAliases = emptyMap<String, String>()
+    private set
 
-    /**
-     * Loads the import aliases from the root [PROPERTY_FILE].
-     * If it can't find it, it defaults to the local [PROPERTY_FILE].
-     */
-    fun loadImportAliases(context: Context) {
-        // Project#getPropertyFiles returns the current module's PROPERTY_FILE file.
-        // To avoid having to define IMPORT_ALIASES_PROPERTY in every module's PROPERTY_FILE,
-        // this loads it from the root folder's PROPERTY_FILE.
+  /**
+   * Loads the import aliases from the root [PROPERTY_FILE].
+   * If it can't find it, it defaults to the local [PROPERTY_FILE].
+   */
+  fun loadImportAliases(context: Context) {
+    // Project#getPropertyFiles returns the current module's PROPERTY_FILE file.
+    // To avoid having to define IMPORT_ALIASES_PROPERTY in every module's PROPERTY_FILE,
+    // this loads it from the root folder's PROPERTY_FILE.
 
-        if (importAliases.isEmpty()) {
-            val root: File? = findRoot(context)
+    if (importAliases.isEmpty()) {
+      val root: File? = findRoot(context)
 
-            File(root, PROPERTY_FILE).run {
-                if (this.exists()) {
-                    val aliasesProperty = getProperty(context, IMPORT_ALIASES_PROPERTY)
-                    if (aliasesProperty != null)
-                        loadFromProperty(aliasesProperty)
-                    else
-                        loadFromLocalPropertyFile(context)
-
-                } else {
-                    loadFromLocalPropertyFile(context)
-                }
-            }
+      File(root, PROPERTY_FILE).run {
+        if (this.exists()) {
+          val aliasesProperty = getProperty(context, IMPORT_ALIASES_PROPERTY)
+          if (aliasesProperty != null)
+            loadFromProperty(aliasesProperty)
+          else
+            loadFromLocalPropertyFile(context)
+        } else {
+          loadFromLocalPropertyFile(context)
         }
+      }
     }
+  }
 
-    /**
-     * Finds the root folder containing the [TOP_LEVEL_FILENAME] file.
-     */
-    private fun findRoot(context: Context): File? {
-        var file: File? = context.project.dir
-        while (file != null && file.listFiles { _, name ->
-                    name.contains(TOP_LEVEL_FILENAME)
-                }?.isEmpty() == true) {
-            file = file.parentFile
-        }
-        return file
+  /**
+   * Finds the root folder containing the [TOP_LEVEL_FILENAME] file.
+   */
+  private fun findRoot(context: Context): File? {
+    var file: File? = context.project.dir
+    while (file != null && file.listFiles { _, name ->
+      name.contains(TOP_LEVEL_FILENAME)
+    }?.isEmpty() == true
+    ) {
+      file = file.parentFile
     }
+    return file
+  }
 
-    private fun File.getProperty(context: Context, key:String): String? {
-        val content = StringReader(context.client.readFile(this).toString())
-        val props = Properties()
-        props.load(content)
-        return props.getProperty(key)
+  private fun File.getProperty(context: Context, key: String): String? {
+    val content = StringReader(context.client.readFile(this).toString())
+    val props = Properties()
+    props.load(content)
+    return props.getProperty(key)
+  }
+
+  private fun loadFromProperty(aliasesProperty: String?) {
+    aliasesProperty?.splitToSequence(",")
+      .orEmpty()
+      .map(String::trim)
+      .filter(String::isNotBlank)
+      .map {
+        val (packageName, alias) = it.split(" as ")
+        packageName.trim() to alias.trim()
+      }.toMap().let { importAliases = it }
+  }
+
+  private fun loadFromLocalPropertyFile(context: Context) {
+    context.project.propertyFiles.find { it.name == PROPERTY_FILE }?.run {
+      loadFromProperty(getProperty(context, IMPORT_ALIASES_PROPERTY))
     }
-
-    private fun loadFromProperty(aliasesProperty: String?) {
-        aliasesProperty?.splitToSequence(",")
-                .orEmpty()
-                .map(String::trim)
-                .filter(String::isNotBlank)
-                .map {
-                    val (packageName, alias) = it.split(" as ")
-                    packageName.trim() to alias.trim()
-                }.toMap().let { importAliases = it }
-    }
-
-
-    private fun loadFromLocalPropertyFile(context: Context) {
-        context.project.propertyFiles.find { it.name == PROPERTY_FILE }?.run {
-            loadFromProperty(getProperty(context, IMPORT_ALIASES_PROPERTY))
-        }
-    }
+  }
 }

--- a/slack-lint/src/main/java/slack/lint/resources/MissingResourceImportAliasDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/MissingResourceImportAliasDetector.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint.resources
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Context
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UImportStatement
+import org.jetbrains.uast.USimpleNameReferenceExpression
+import org.jetbrains.uast.getContainingUFile
+import org.jetbrains.uast.getQualifiedParentOrThis
+import slack.lint.resources.model.IMPORT_ALIASES
+import slack.lint.resources.model.RootIssueData
+import slack.lint.util.sourceImplementation
+
+/** Reports an error when an R class, other than the local module's, is imported without an import alias. */
+class MissingResourceImportAliasDetector : Detector(), SourceCodeScanner {
+
+  private val fixes = mutableListOf<LintFix>()
+  private var rootIssueData: RootIssueData? = null
+
+  override fun afterCheckFile(context: Context) {
+    rootIssueData?.let {
+      context.report(
+        ISSUE,
+        it.nameLocation,
+        "Please use an import alias here",
+        quickfixData =
+        fix()
+          .name("Add import alias")
+          // Apply the fixes in reverse so that the ranges/locations don't change.
+          .composite(*fixes.reversed().toTypedArray())
+          .autoFix()
+      )
+      rootIssueData = null
+      fixes.clear()
+    }
+  }
+
+  override fun getApplicableUastTypes(): List<Class<out UElement>> =
+    listOf(UImportStatement::class.java, USimpleNameReferenceExpression::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    return object : UElementHandler() {
+
+      override fun visitImportStatement(node: UImportStatement) {
+        // Import alias is a Kotlin feature.
+        val importDirective = node.sourcePsi as? KtImportDirective ?: return
+
+        if (importDirective.importedName?.identifier == "R" && importDirective.aliasName == null) {
+          val packageName = node.getContainingUFile()?.packageName ?: return
+
+          val importedFqName = importDirective.importedFqName
+          val parentImportedFqName = importedFqName?.parent()?.asString()
+
+          val isLocalResourceImport = parentImportedFqName?.let { packageName.startsWith(it) } ?: true
+          if (!isLocalResourceImport) {
+            val importedFqNameString = requireNotNull(importedFqName).asString()
+            val alias = IMPORT_ALIASES[importedFqNameString]
+
+            if (alias != null) {
+              rootIssueData = RootIssueData(alias = alias, nameLocation = context.getNameLocation(importDirective))
+
+              fixes.add(createImportLintFix(importDirective, importedFqNameString, alias))
+            } else {
+              context.report(ISSUE, context.getNameLocation(importDirective), "Please use an import alias here")
+            }
+          }
+        }
+      }
+
+      private fun createImportLintFix(importDirective: KtImportDirective, importedFqNameString: String, alias: String?): LintFix {
+        return fix()
+          .replace()
+          .range(context.getLocation(importDirective))
+          .text(importedFqNameString)
+          .with("$importedFqNameString as $alias")
+          .build()
+      }
+
+      override fun visitSimpleNameReferenceExpression(node: USimpleNameReferenceExpression) {
+        rootIssueData?.alias?.let {
+          if (node.asSourceString() == "R" &&
+            // Make sure node is its own parent to safeguard against cases like Build.VERSION_CODES.R.
+            node.getQualifiedParentOrThis() == node
+          ) {
+            fixes.add(createReferenceLintFix(node, it))
+          }
+        }
+      }
+
+      private fun createReferenceLintFix(node: USimpleNameReferenceExpression, alias: String): LintFix {
+        return fix().replace().range(context.getLocation(node)).with(alias).build()
+      }
+    }
+  }
+
+  companion object {
+    val ISSUE: Issue =
+      Issue.create(
+        "MissingResourceImportAlias",
+        "Missing import alias for R class.",
+        """
+          Only the local module's R class is allowed to be imported without an alias. \
+          Please add an import alias for this. For example, import slack.l10n.R as L10nR
+          """,
+        Category.CORRECTNESS,
+        6,
+        Severity.ERROR,
+        sourceImplementation<MissingResourceImportAliasDetector>()
+      )
+  }
+}

--- a/slack-lint/src/main/java/slack/lint/resources/MissingResourceImportAliasDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/MissingResourceImportAliasDetector.kt
@@ -47,6 +47,8 @@ class MissingResourceImportAliasDetector : Detector(), SourceCodeScanner {
   }
 
   override fun afterCheckFile(context: Context) {
+    // Collect all the fixes and apply them to one issue on the import to avoid adding the import alias with a fix
+    // and leaving the R references still referencing the non-aliased R or vice versa.
     rootIssueData?.let {
       context.report(
         ISSUE,

--- a/slack-lint/src/main/java/slack/lint/resources/MissingResourceImportAliasDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/MissingResourceImportAliasDetector.kt
@@ -45,7 +45,7 @@ class MissingResourceImportAliasDetector : Detector(), SourceCodeScanner {
       context.report(
         ISSUE,
         it.nameLocation,
-        "Please use an import alias here",
+        "Use an import alias for R classes from other modules",
         quickfixData =
         fix()
           .name("Add import alias")
@@ -84,7 +84,7 @@ class MissingResourceImportAliasDetector : Detector(), SourceCodeScanner {
 
               fixes.add(createImportLintFix(importDirective, importedFqNameString, alias))
             } else {
-              context.report(ISSUE, context.getNameLocation(importDirective), "Please use an import alias here")
+              context.report(ISSUE, context.getNameLocation(importDirective), "Use an import alias for R classes from other modules")
             }
           }
         }
@@ -123,7 +123,7 @@ class MissingResourceImportAliasDetector : Detector(), SourceCodeScanner {
         "Missing import alias for R class.",
         """
           Only the local module's R class is allowed to be imported without an alias. \
-          Please add an import alias for this. For example, import slack.l10n.R as L10nR
+          Add an import alias for this. For example, import slack.l10n.R as L10nR
           """,
         Category.CORRECTNESS,
         6,

--- a/slack-lint/src/main/java/slack/lint/resources/MissingResourceImportAliasDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/MissingResourceImportAliasDetector.kt
@@ -30,7 +30,7 @@ import org.jetbrains.uast.UImportStatement
 import org.jetbrains.uast.USimpleNameReferenceExpression
 import org.jetbrains.uast.getContainingUFile
 import org.jetbrains.uast.getQualifiedParentOrThis
-import slack.lint.resources.model.IMPORT_ALIASES
+import slack.lint.resources.ImportAliasesLoader.importAliases
 import slack.lint.resources.model.RootIssueData
 import slack.lint.util.sourceImplementation
 
@@ -39,6 +39,12 @@ class MissingResourceImportAliasDetector : Detector(), SourceCodeScanner {
 
   private val fixes = mutableListOf<LintFix>()
   private var rootIssueData: RootIssueData? = null
+
+  override fun beforeCheckRootProject(context: Context) {
+    super.beforeCheckRootProject(context)
+
+    ImportAliasesLoader.loadImportAliases(context)
+  }
 
   override fun afterCheckFile(context: Context) {
     rootIssueData?.let {
@@ -77,7 +83,7 @@ class MissingResourceImportAliasDetector : Detector(), SourceCodeScanner {
           val isLocalResourceImport = parentImportedFqName?.let { packageName.startsWith(it) } ?: true
           if (!isLocalResourceImport) {
             val importedFqNameString = requireNotNull(importedFqName).asString()
-            val alias = IMPORT_ALIASES[importedFqNameString]
+            val alias = importAliases[importedFqNameString]
 
             if (alias != null) {
               rootIssueData = RootIssueData(alias = alias, nameLocation = context.getNameLocation(importDirective))

--- a/slack-lint/src/main/java/slack/lint/resources/MissingResourceImportAliasDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/MissingResourceImportAliasDetector.kt
@@ -30,7 +30,7 @@ import org.jetbrains.uast.UImportStatement
 import org.jetbrains.uast.USimpleNameReferenceExpression
 import org.jetbrains.uast.getContainingUFile
 import org.jetbrains.uast.getQualifiedParentOrThis
-import slack.lint.resources.ImportAliasesLoader.importAliases
+import slack.lint.resources.ImportAliasesLoader.IMPORT_ALIASES
 import slack.lint.resources.model.RootIssueData
 import slack.lint.util.sourceImplementation
 
@@ -40,10 +40,12 @@ class MissingResourceImportAliasDetector : Detector(), SourceCodeScanner {
   private val fixes = mutableListOf<LintFix>()
   private var rootIssueData: RootIssueData? = null
 
+  private lateinit var importAliases: Map<String, String>
+
   override fun beforeCheckRootProject(context: Context) {
     super.beforeCheckRootProject(context)
 
-    ImportAliasesLoader.loadImportAliases(context)
+    importAliases = ImportAliasesLoader.loadImportAliases(context)
   }
 
   override fun afterCheckFile(context: Context) {
@@ -137,6 +139,6 @@ class MissingResourceImportAliasDetector : Detector(), SourceCodeScanner {
         6,
         Severity.ERROR,
         sourceImplementation<MissingResourceImportAliasDetector>()
-      )
+      ).setOptions(listOf(IMPORT_ALIASES))
   }
 }

--- a/slack-lint/src/main/java/slack/lint/resources/WrongResourceImportAliasDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/WrongResourceImportAliasDetector.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint.resources
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Context
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UImportStatement
+import org.jetbrains.uast.USimpleNameReferenceExpression
+import slack.lint.resources.model.IMPORT_ALIASES
+import slack.lint.resources.model.RootIssueData
+import slack.lint.util.sourceImplementation
+
+/** Reports an error when an R class is imported using the wrong import alias. */
+class WrongResourceImportAliasDetector : Detector(), SourceCodeScanner {
+
+  private val fixes = mutableListOf<LintFix>()
+  private var rootIssueData: RootIssueData? = null
+
+  override fun afterCheckFile(context: Context) {
+    rootIssueData?.let {
+      context.report(
+        ISSUE,
+        it.nameLocation,
+        "Please use ${it.alias} as an import alias here",
+        quickfixData = fix()
+          .name("Replace import alias")
+          // Apply the fixes in reverse so that the ranges/locations don't change.
+          .composite(*fixes.reversed().toTypedArray())
+          .autoFix()
+      )
+
+      reset()
+    }
+  }
+
+  private fun reset() {
+    rootIssueData = null
+    fixes.clear()
+  }
+
+  override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(UImportStatement::class.java, USimpleNameReferenceExpression::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    return object : UElementHandler() {
+      private var wrongAlias: String? = null
+
+      override fun visitImportStatement(node: UImportStatement) {
+        // Import alias is a Kotlin feature.
+        val importDirective = node.sourcePsi as? KtImportDirective ?: return
+
+        // In case of multiple wrong aliases, only fix the first one.
+        if (wrongAlias != null) return
+
+        val importedFqNameString = importDirective.importedFqName?.asString() ?: return
+        if (importedFqNameString.endsWith(".R") && importDirective.aliasName != null) {
+          IMPORT_ALIASES[importedFqNameString]?.let { alias ->
+            val aliasName = importDirective.aliasName
+            if (alias != aliasName) {
+              this.wrongAlias = aliasName
+              this@WrongResourceImportAliasDetector.rootIssueData =
+                RootIssueData(
+                  alias = alias,
+                  nameLocation = context.getNameLocation(importDirective)
+                )
+
+              fixes.add(createImportLintFix(node, importedFqNameString, aliasName, alias))
+            }
+          }
+        }
+      }
+
+      private fun createImportLintFix(
+        node: UImportStatement,
+        importedFqNameString: String,
+        aliasName: String?,
+        alias: String
+      ): LintFix {
+        return fix()
+          .replace()
+          .range(context.getLocation(node))
+          .text("$importedFqNameString as $aliasName")
+          .with("$importedFqNameString as $alias")
+          .build()
+      }
+
+      override fun visitSimpleNameReferenceExpression(node: USimpleNameReferenceExpression) {
+        wrongAlias?.let {
+          if (node.asSourceString() == it) {
+            fixes.add(createReferenceLintFix(node))
+          }
+        }
+      }
+
+      private fun createReferenceLintFix(node: USimpleNameReferenceExpression): LintFix {
+        return fix()
+          .replace()
+          .range(context.getLocation(node))
+          .with(rootIssueData?.alias)
+          .build()
+      }
+    }
+  }
+
+  companion object {
+
+    val ISSUE: Issue =
+      Issue.create(
+        "WrongResourceImportAlias",
+        "Wrong import alias for this R class.",
+        "R class import aliases should be consistent across the codebase. For example: \n" +
+          "import slack.l10n.R as L10nR\n" +
+          "import slack.uikit.R as UiKitR",
+        Category.CORRECTNESS,
+        6,
+        Severity.ERROR,
+        sourceImplementation<WrongResourceImportAliasDetector>()
+      )
+  }
+}

--- a/slack-lint/src/main/java/slack/lint/resources/WrongResourceImportAliasDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/WrongResourceImportAliasDetector.kt
@@ -43,7 +43,7 @@ class WrongResourceImportAliasDetector : Detector(), SourceCodeScanner {
       context.report(
         ISSUE,
         it.nameLocation,
-        "Please use ${it.alias} as an import alias here",
+        "Use ${it.alias} as an import alias here",
         quickfixData = fix()
           .name("Replace import alias")
           // Apply the fixes in reverse so that the ranges/locations don't change.

--- a/slack-lint/src/main/java/slack/lint/resources/WrongResourceImportAliasDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/WrongResourceImportAliasDetector.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UImportStatement
 import org.jetbrains.uast.USimpleNameReferenceExpression
-import slack.lint.resources.model.IMPORT_ALIASES
+import slack.lint.resources.ImportAliasesLoader.importAliases
 import slack.lint.resources.model.RootIssueData
 import slack.lint.util.sourceImplementation
 
@@ -37,6 +37,12 @@ class WrongResourceImportAliasDetector : Detector(), SourceCodeScanner {
 
   private val fixes = mutableListOf<LintFix>()
   private var rootIssueData: RootIssueData? = null
+
+  override fun beforeCheckRootProject(context: Context) {
+    super.beforeCheckRootProject(context)
+
+    ImportAliasesLoader.loadImportAliases(context)
+  }
 
   override fun afterCheckFile(context: Context) {
     rootIssueData?.let {
@@ -75,7 +81,7 @@ class WrongResourceImportAliasDetector : Detector(), SourceCodeScanner {
 
         val importedFqNameString = importDirective.importedFqName?.asString() ?: return
         if (importedFqNameString.endsWith(".R") && importDirective.aliasName != null) {
-          IMPORT_ALIASES[importedFqNameString]?.let { alias ->
+          importAliases[importedFqNameString]?.let { alias ->
             val aliasName = importDirective.aliasName
             if (alias != aliasName) {
               this.wrongAlias = aliasName

--- a/slack-lint/src/main/java/slack/lint/resources/WrongResourceImportAliasDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/WrongResourceImportAliasDetector.kt
@@ -45,6 +45,8 @@ class WrongResourceImportAliasDetector : Detector(), SourceCodeScanner {
   }
 
   override fun afterCheckFile(context: Context) {
+    // Collect all the fixes and apply them to one issue on the import to avoid renaming the import alias with a fix
+    // and leaving the R references still referencing the old import alias or vice versa.
     rootIssueData?.let {
       context.report(
         ISSUE,

--- a/slack-lint/src/main/java/slack/lint/resources/WrongResourceImportAliasDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/WrongResourceImportAliasDetector.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UImportStatement
 import org.jetbrains.uast.USimpleNameReferenceExpression
-import slack.lint.resources.ImportAliasesLoader.importAliases
+import slack.lint.resources.ImportAliasesLoader.IMPORT_ALIASES
 import slack.lint.resources.model.RootIssueData
 import slack.lint.util.sourceImplementation
 
@@ -38,10 +38,12 @@ class WrongResourceImportAliasDetector : Detector(), SourceCodeScanner {
   private val fixes = mutableListOf<LintFix>()
   private var rootIssueData: RootIssueData? = null
 
+  private lateinit var importAliases: Map<String, String>
+
   override fun beforeCheckRootProject(context: Context) {
     super.beforeCheckRootProject(context)
 
-    ImportAliasesLoader.loadImportAliases(context)
+    importAliases = ImportAliasesLoader.loadImportAliases(context)
   }
 
   override fun afterCheckFile(context: Context) {
@@ -144,6 +146,6 @@ class WrongResourceImportAliasDetector : Detector(), SourceCodeScanner {
         6,
         Severity.ERROR,
         sourceImplementation<WrongResourceImportAliasDetector>()
-      )
+      ).setOptions(listOf(IMPORT_ALIASES))
   }
 }

--- a/slack-lint/src/main/java/slack/lint/resources/model/RootIssueData.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/model/RootIssueData.kt
@@ -18,11 +18,3 @@ package slack.lint.resources.model
 import com.android.tools.lint.detector.api.Location
 
 data class RootIssueData(val alias: String, val nameLocation: Location)
-
-val IMPORT_ALIASES =
-  mapOf(
-    "slack.l10n.R" to "L10nR",
-    "slack.uikit.resources.R" to "SlackKitR",
-    "slack.uikit.R" to "UiKitR",
-    "slack.coreui.R" to "CoreUiR"
-  )

--- a/slack-lint/src/main/java/slack/lint/resources/model/RootIssueData.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/model/RootIssueData.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint.resources.model
+
+import com.android.tools.lint.detector.api.Location
+
+data class RootIssueData(val alias: String, val nameLocation: Location)
+
+val IMPORT_ALIASES =
+  mapOf(
+    "slack.l10n.R" to "L10nR",
+    "slack.uikit.resources.R" to "SlackKitR",
+    "slack.uikit.R" to "UiKitR",
+    "slack.coreui.R" to "CoreUiR"
+  )

--- a/slack-lint/src/test/java/slack/lint/resources/FullyQualifiedResourceDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/FullyQualifiedResourceDetectorTest.kt
@@ -1,0 +1,314 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint.resources
+
+import com.android.tools.lint.detector.api.Detector
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+
+class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
+
+  override fun getDetector(): Detector = FullyQualifiedResourceDetector()
+
+  override fun getIssues() = listOf(FullyQualifiedResourceDetector.ISSUE)
+
+  @Test
+  fun `test success`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.l10n.R as L10nR
+
+           class MyClass {
+
+             init {
+                  val appName = getString(L10R.string.app_name)
+              }
+
+           }
+          """
+        ).indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `test failure no imports`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+           class MyClass {
+
+             init {
+                  val appName = getString(slack.l10n.R.string.app_name)
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:6: Error: Please use L10nR as an import alias instead [FullyQualifiedResource]
+                val appName = getString(slack.l10n.R.string.app_name)
+                                        ~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 6: Replace import alias:
+        @@ -3 +3
+        + import slack.l10n.R as L10nR
+        +
+        @@ -6 +8
+        -         val appName = getString(slack.l10n.R.string.app_name)
+        +         val appName = getString(L10nR.string.app_name)
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `test failure no import`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.pkg.R
+
+           class MyClass {
+
+             init {
+                  val appName = getString(slack.l10n.R.string.app_name)
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:8: Error: Please use L10nR as an import alias instead [FullyQualifiedResource]
+                val appName = getString(slack.l10n.R.string.app_name)
+                                        ~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 8: Replace import alias:
+        @@ -4 +4
+        + import slack.l10n.R as L10nR
+        @@ -8 +9
+        -         val appName = getString(slack.l10n.R.string.app_name)
+        +         val appName = getString(L10nR.string.app_name)
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `test failure import`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.pkg.R
+          import slack.l10n.R as L10nR
+
+           class MyClass {
+
+             init {
+                  val appName = getString(slack.l10n.R.string.app_name)
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:9: Error: Please use L10nR as an import alias instead [FullyQualifiedResource]
+                val appName = getString(slack.l10n.R.string.app_name)
+                                        ~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 9: Replace import alias:
+        @@ -9 +9
+        -         val appName = getString(slack.l10n.R.string.app_name)
+        +         val appName = getString(L10nR.string.app_name)
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `test failure import without alias`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.l10n.R
+
+           class MyClass {
+
+             init {
+                  val appName = getString(slack.l10n.R.string.app_name)
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:8: Error: Please use L10nR as an import alias instead [FullyQualifiedResource]
+                val appName = getString(slack.l10n.R.string.app_name)
+                                        ~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 8: Replace import alias:
+        @@ -4 +4
+        + import slack.l10n.R as L10nR
+        @@ -8 +9
+        -         val appName = getString(slack.l10n.R.string.app_name)
+        +         val appName = getString(L10nR.string.app_name)
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `test failure import wrong alias`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.l10n.R as L10R
+
+           class MyClass {
+
+             init {
+                  val appName = getString(slack.l10n.R.string.app_name)
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:8: Error: Please use L10nR as an import alias instead [FullyQualifiedResource]
+                val appName = getString(slack.l10n.R.string.app_name)
+                                        ~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 8: Replace import alias:
+        @@ -4 +4
+        + import slack.l10n.R as L10nR
+        @@ -8 +9
+        -         val appName = getString(slack.l10n.R.string.app_name)
+        +         val appName = getString(L10nR.string.app_name)
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `test failure no fix`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.l10n.R as L10R
+
+           class MyClass {
+
+             init {
+                  val appName = getString(slack.pkg.R.string.app_name)
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:8: Error: Please use an import alias instead [FullyQualifiedResource]
+                val appName = getString(slack.pkg.R.string.app_name)
+                                        ~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs("")
+  }
+
+  @Test
+  fun `test java no-op`() {
+    lint()
+      .files(
+        java(
+          """
+          package slack.pkg.subpackage;
+
+           class MyClass {
+            MyClass(){
+            String appName = getString(slack.l10n.R.string.app_name);
+           }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+}

--- a/slack-lint/src/test/java/slack/lint/resources/FullyQualifiedResourceDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/FullyQualifiedResourceDetectorTest.kt
@@ -35,7 +35,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
 
           import slack.l10n.R as L10nR
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(L10R.string.app_name)
@@ -57,7 +57,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
           """
           package slack.pkg.subpackage
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(slack.l10n.R.string.app_name)
@@ -100,7 +100,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
 
           import slack.pkg.R
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(slack.l10n.R.string.app_name)
@@ -143,7 +143,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
           import slack.pkg.R
           import slack.l10n.R as L10nR
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(slack.l10n.R.string.app_name)
@@ -183,7 +183,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
 
           import slack.l10n.R
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(slack.l10n.R.string.app_name)
@@ -225,7 +225,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
 
           import slack.l10n.R as L10R
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(slack.l10n.R.string.app_name)
@@ -267,7 +267,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
 
           import slack.l10n.R as L10R
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(slack.pkg.R.string.app_name)
@@ -298,7 +298,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
           """
           package slack.pkg.subpackage;
 
-           class MyClass {
+          class MyClass {
             MyClass(){
             String appName = getString(slack.l10n.R.string.app_name);
            }

--- a/slack-lint/src/test/java/slack/lint/resources/FullyQualifiedResourceDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/FullyQualifiedResourceDetectorTest.kt
@@ -15,11 +15,19 @@
  */
 package slack.lint.resources
 
+import com.android.tools.lint.checks.infrastructure.TestFile
 import com.android.tools.lint.detector.api.Detector
 import org.junit.Test
 import slack.lint.BaseSlackLintTest
 
 class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
+  private fun propertiesFile(): TestFile.PropertyTestFile = projectProperties().apply {
+      property(
+              ImportAliasesLoader.IMPORT_ALIASES_PROPERTY,
+              "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
+      )
+      to(ImportAliasesLoader.PROPERTY_FILE)
+  }
 
   override fun getDetector(): Detector = FullyQualifiedResourceDetector()
 
@@ -29,6 +37,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test success`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -53,6 +62,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test failure no imports`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -94,6 +104,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test failure no import`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -136,6 +147,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test failure import`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -177,6 +189,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test failure import without alias`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -219,6 +232,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test failure import wrong alias`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -261,6 +275,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test failure no fix`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -294,6 +309,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test java no-op`() {
     lint()
       .files(
+        propertiesFile(),
         java(
           """
           package slack.pkg.subpackage;

--- a/slack-lint/src/test/java/slack/lint/resources/FullyQualifiedResourceDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/FullyQualifiedResourceDetectorTest.kt
@@ -22,11 +22,11 @@ import slack.lint.BaseSlackLintTest
 
 class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   private fun propertiesFile(): TestFile.PropertyTestFile = projectProperties().apply {
-      property(
-              ImportAliasesLoader.IMPORT_ALIASES_PROPERTY,
-              "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
-      )
-      to(ImportAliasesLoader.PROPERTY_FILE)
+    property(
+      ImportAliasesLoader.IMPORT_ALIASES_PROPERTY,
+      "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
+    )
+    to(ImportAliasesLoader.PROPERTY_FILE)
   }
 
   override fun getDetector(): Detector = FullyQualifiedResourceDetector()

--- a/slack-lint/src/test/java/slack/lint/resources/FullyQualifiedResourceDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/FullyQualifiedResourceDetectorTest.kt
@@ -71,7 +71,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:6: Error: Please use L10nR as an import alias instead [FullyQualifiedResource]
+        src/slack/pkg/subpackage/MyClass.kt:6: Error: Use L10nR as an import alias instead [FullyQualifiedResource]
                 val appName = getString(slack.l10n.R.string.app_name)
                                         ~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -114,7 +114,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:8: Error: Please use L10nR as an import alias instead [FullyQualifiedResource]
+        src/slack/pkg/subpackage/MyClass.kt:8: Error: Use L10nR as an import alias instead [FullyQualifiedResource]
                 val appName = getString(slack.l10n.R.string.app_name)
                                         ~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -157,7 +157,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:9: Error: Please use L10nR as an import alias instead [FullyQualifiedResource]
+        src/slack/pkg/subpackage/MyClass.kt:9: Error: Use L10nR as an import alias instead [FullyQualifiedResource]
                 val appName = getString(slack.l10n.R.string.app_name)
                                         ~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -197,7 +197,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:8: Error: Please use L10nR as an import alias instead [FullyQualifiedResource]
+        src/slack/pkg/subpackage/MyClass.kt:8: Error: Use L10nR as an import alias instead [FullyQualifiedResource]
                 val appName = getString(slack.l10n.R.string.app_name)
                                         ~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -239,7 +239,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:8: Error: Please use L10nR as an import alias instead [FullyQualifiedResource]
+        src/slack/pkg/subpackage/MyClass.kt:8: Error: Use L10nR as an import alias instead [FullyQualifiedResource]
                 val appName = getString(slack.l10n.R.string.app_name)
                                         ~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -281,7 +281,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:8: Error: Please use an import alias instead [FullyQualifiedResource]
+        src/slack/pkg/subpackage/MyClass.kt:8: Error: Use an import alias instead [FullyQualifiedResource]
                 val appName = getString(slack.pkg.R.string.app_name)
                                         ~~~~~~~~~~~
         1 errors, 0 warnings

--- a/slack-lint/src/test/java/slack/lint/resources/FullyQualifiedResourceDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/FullyQualifiedResourceDetectorTest.kt
@@ -15,29 +15,30 @@
  */
 package slack.lint.resources
 
-import com.android.tools.lint.checks.infrastructure.TestFile
+import com.android.tools.lint.checks.infrastructure.TestLintTask
 import com.android.tools.lint.detector.api.Detector
 import org.junit.Test
 import slack.lint.BaseSlackLintTest
+import slack.lint.resources.ImportAliasesLoader.IMPORT_ALIASES
 
 class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
-  private fun propertiesFile(): TestFile.PropertyTestFile = projectProperties().apply {
-    property(
-      ImportAliasesLoader.IMPORT_ALIASES_PROPERTY,
-      "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
-    )
-    to(ImportAliasesLoader.PROPERTY_FILE)
-  }
 
   override fun getDetector(): Detector = FullyQualifiedResourceDetector()
 
   override fun getIssues() = listOf(FullyQualifiedResourceDetector.ISSUE)
 
+  override fun lint(): TestLintTask {
+    return super.lint()
+      .configureOption(
+        IMPORT_ALIASES,
+        "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
+      )
+  }
+
   @Test
   fun `test success`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -62,7 +63,6 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test failure no imports`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -104,7 +104,6 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test failure no import`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -147,7 +146,6 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test failure import`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -189,7 +187,6 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test failure import without alias`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -232,7 +229,6 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test failure import wrong alias`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -275,7 +271,6 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test failure no fix`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -309,7 +304,6 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
   fun `test java no-op`() {
     lint()
       .files(
-        propertiesFile(),
         java(
           """
           package slack.pkg.subpackage;

--- a/slack-lint/src/test/java/slack/lint/resources/MissingResourceImportAliasDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/MissingResourceImportAliasDetectorTest.kt
@@ -15,30 +15,29 @@
  */
 package slack.lint.resources
 
-import com.android.tools.lint.checks.infrastructure.TestFile
+import com.android.tools.lint.checks.infrastructure.TestLintTask
 import com.android.tools.lint.detector.api.Detector
 import org.junit.Test
 import slack.lint.BaseSlackLintTest
 
 class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
 
-  private fun propertiesFile(): TestFile.PropertyTestFile = projectProperties().apply {
-    property(
-      ImportAliasesLoader.IMPORT_ALIASES_PROPERTY,
-      "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
-    )
-    to(ImportAliasesLoader.PROPERTY_FILE)
-  }
-
   override fun getDetector(): Detector = MissingResourceImportAliasDetector()
 
   override fun getIssues() = listOf(MissingResourceImportAliasDetector.ISSUE)
+
+  override fun lint(): TestLintTask {
+    return super.lint()
+      .configureOption(
+        ImportAliasesLoader.IMPORT_ALIASES,
+        "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
+      )
+  }
 
   @Test
   fun `test success`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -65,7 +64,6 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure no references`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -100,7 +98,6 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure one reference`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -144,7 +141,6 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure multiple references`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -191,7 +187,6 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure VERSION_CODES R reference`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -241,7 +236,6 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure no fix`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -275,7 +269,6 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test java no-op`() {
     lint()
       .files(
-        propertiesFile(),
         java(
           """
           package slack.pkg.subpackage;

--- a/slack-lint/src/test/java/slack/lint/resources/MissingResourceImportAliasDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/MissingResourceImportAliasDetectorTest.kt
@@ -36,7 +36,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
           import slack.l10n.R as L10nR
           import slack.pkg.R
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(L10R.string.app_name)
@@ -61,7 +61,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
 
           import slack.l10n.R
 
-           class MyClass
+          class MyClass
           """
         )
           .indented()
@@ -95,7 +95,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
 
           import slack.l10n.R
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(R.string.app_name)
@@ -138,7 +138,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
 
           import slack.l10n.R
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(R.string.app_name) + "-" + getString(R.string.suffix)
@@ -184,7 +184,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
 
           import slack.l10n.R
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(R.string.app_name) + "-" + getString(R.string.suffix)
@@ -233,7 +233,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
 
           import slack.pkg.subpkg.R
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(R.string.app_name)
@@ -266,7 +266,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
 
           import slack.pkg.subpkg.R;
 
-           class MyClass {
+          class MyClass {
 
              MyClass() {
                   String appName = getString(R.string.app_name);

--- a/slack-lint/src/test/java/slack/lint/resources/MissingResourceImportAliasDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/MissingResourceImportAliasDetectorTest.kt
@@ -69,7 +69,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use an import alias here [MissingResourceImportAlias]
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
         import slack.l10n.R
         ~~~~~~~~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -109,7 +109,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use an import alias here [MissingResourceImportAlias]
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
         import slack.l10n.R
         ~~~~~~~~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -153,7 +153,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use an import alias here [MissingResourceImportAlias]
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
         import slack.l10n.R
         ~~~~~~~~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -201,7 +201,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use an import alias here [MissingResourceImportAlias]
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
         import slack.l10n.R
         ~~~~~~~~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -247,7 +247,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use an import alias here [MissingResourceImportAlias]
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
         import slack.pkg.subpkg.R
         ~~~~~~~~~~~~~~~~~~~~~~~~~
         1 errors, 0 warnings

--- a/slack-lint/src/test/java/slack/lint/resources/MissingResourceImportAliasDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/MissingResourceImportAliasDetectorTest.kt
@@ -15,11 +15,20 @@
  */
 package slack.lint.resources
 
+import com.android.tools.lint.checks.infrastructure.TestFile
 import com.android.tools.lint.detector.api.Detector
 import org.junit.Test
 import slack.lint.BaseSlackLintTest
 
 class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
+
+  private fun propertiesFile(): TestFile.PropertyTestFile = projectProperties().apply {
+      property(
+              ImportAliasesLoader.IMPORT_ALIASES_PROPERTY,
+              "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
+      )
+      to(ImportAliasesLoader.PROPERTY_FILE)
+  }
 
   override fun getDetector(): Detector = MissingResourceImportAliasDetector()
 
@@ -29,6 +38,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test success`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -55,6 +65,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure no references`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -89,6 +100,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure one reference`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -132,6 +144,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure multiple references`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -178,6 +191,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure VERSION_CODES R reference`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -227,6 +241,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure no fix`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -260,6 +275,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test java no-op`() {
     lint()
       .files(
+        propertiesFile(),
         java(
           """
           package slack.pkg.subpackage;

--- a/slack-lint/src/test/java/slack/lint/resources/MissingResourceImportAliasDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/MissingResourceImportAliasDetectorTest.kt
@@ -23,11 +23,11 @@ import slack.lint.BaseSlackLintTest
 class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
 
   private fun propertiesFile(): TestFile.PropertyTestFile = projectProperties().apply {
-      property(
-              ImportAliasesLoader.IMPORT_ALIASES_PROPERTY,
-              "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
-      )
-      to(ImportAliasesLoader.PROPERTY_FILE)
+    property(
+      ImportAliasesLoader.IMPORT_ALIASES_PROPERTY,
+      "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
+    )
+    to(ImportAliasesLoader.PROPERTY_FILE)
   }
 
   override fun getDetector(): Detector = MissingResourceImportAliasDetector()

--- a/slack-lint/src/test/java/slack/lint/resources/MissingResourceImportAliasDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/MissingResourceImportAliasDetectorTest.kt
@@ -1,0 +1,283 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint.resources
+
+import com.android.tools.lint.detector.api.Detector
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+
+class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
+
+  override fun getDetector(): Detector = MissingResourceImportAliasDetector()
+
+  override fun getIssues() = listOf(MissingResourceImportAliasDetector.ISSUE)
+
+  @Test
+  fun `test success`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.l10n.R as L10nR
+          import slack.pkg.R
+
+           class MyClass {
+
+             init {
+                  val appName = getString(L10R.string.app_name)
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `test failure no references`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.l10n.R
+
+           class MyClass
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use an import alias here [MissingResourceImportAlias]
+        import slack.l10n.R
+        ~~~~~~~~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 3: Add import alias:
+        @@ -3 +3
+        - import slack.l10n.R
+        + import slack.l10n.R as L10nR
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `test failure one reference`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.l10n.R
+
+           class MyClass {
+
+             init {
+                  val appName = getString(R.string.app_name)
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use an import alias here [MissingResourceImportAlias]
+        import slack.l10n.R
+        ~~~~~~~~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 3: Add import alias:
+        @@ -3 +3
+        - import slack.l10n.R
+        + import slack.l10n.R as L10nR
+        @@ -8 +8
+        -         val appName = getString(R.string.app_name)
+        +         val appName = getString(L10nR.string.app_name)
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `test failure multiple references`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.l10n.R
+
+           class MyClass {
+
+             init {
+                  val appName = getString(R.string.app_name) + "-" + getString(R.string.suffix)
+                  getColor(R.color.transparent).let { println(it) }
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use an import alias here [MissingResourceImportAlias]
+        import slack.l10n.R
+        ~~~~~~~~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 3: Add import alias:
+        @@ -3 +3
+        - import slack.l10n.R
+        + import slack.l10n.R as L10nR
+        @@ -8 +8
+        -         val appName = getString(R.string.app_name) + "-" + getString(R.string.suffix)
+        -         getColor(R.color.transparent).let { println(it) }
+        +         val appName = getString(L10nR.string.app_name) + "-" + getString(L10nR.string.suffix)
+        +         getColor(L10nR.color.transparent).let { println(it) }
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `test failure VERSION_CODES R reference`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.l10n.R
+
+           class MyClass {
+
+             init {
+                  val appName = getString(R.string.app_name) + "-" + getString(R.string.suffix)
+                  if (isAtLeastApi(Build.VERSION_CODES.R)) {
+                        getColor(R.color.transparent).let { println(it) }
+                  }
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use an import alias here [MissingResourceImportAlias]
+        import slack.l10n.R
+        ~~~~~~~~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 3: Add import alias:
+        @@ -3 +3
+        - import slack.l10n.R
+        + import slack.l10n.R as L10nR
+        @@ -8 +8
+        -         val appName = getString(R.string.app_name) + "-" + getString(R.string.suffix)
+        +         val appName = getString(L10nR.string.app_name) + "-" + getString(L10nR.string.suffix)
+        @@ -10 +10
+        -               getColor(R.color.transparent).let { println(it) }
+        +               getColor(L10nR.color.transparent).let { println(it) }
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `test failure no fix`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.pkg.subpkg.R
+
+           class MyClass {
+
+             init {
+                  val appName = getString(R.string.app_name)
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use an import alias here [MissingResourceImportAlias]
+        import slack.pkg.subpkg.R
+        ~~~~~~~~~~~~~~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs("")
+  }
+
+  @Test
+  fun `test java no-op`() {
+    lint()
+      .files(
+        java(
+          """
+          package slack.pkg.subpackage;
+
+          import slack.pkg.subpkg.R;
+
+           class MyClass {
+
+             MyClass() {
+                  String appName = getString(R.string.app_name);
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+}

--- a/slack-lint/src/test/java/slack/lint/resources/WrongResourceImportAliasDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/WrongResourceImportAliasDetectorTest.kt
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint.resources
+
+import com.android.tools.lint.detector.api.Detector
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+
+class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
+
+  override fun getDetector(): Detector = WrongResourceImportAliasDetector()
+
+  override fun getIssues() = listOf(WrongResourceImportAliasDetector.ISSUE)
+
+  @Test
+  fun `test success`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.l10n.R as L10nR
+          import slack.pkg.R
+
+           class MyClass {
+
+             init {
+                  val appName = getString(L10R.string.app_name)
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `test failure no references`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.l10n.R as L10R
+
+           class MyClass
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use L10nR as an import alias here [WrongResourceImportAlias]
+        import slack.l10n.R as L10R
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 3: Replace import alias:
+        @@ -3 +3
+        - import slack.l10n.R as L10R
+        + import slack.l10n.R as L10nR
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `test failure one reference`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.uikit.resources.R as SlackKitR
+          import slack.l10n.R as L10R
+
+           class MyClass {
+
+             init {
+                  val appName = getString(L10R.string.app_name)
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:4: Error: Please use L10nR as an import alias here [WrongResourceImportAlias]
+        import slack.l10n.R as L10R
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 4: Replace import alias:
+        @@ -4 +4
+        - import slack.l10n.R as L10R
+        + import slack.l10n.R as L10nR
+        @@ -9 +9
+        -         val appName = getString(L10R.string.app_name)
+        +         val appName = getString(L10nR.string.app_name)
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `test failure multiple references`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.l10n.R as L10R
+
+           class MyClass {
+
+             init {
+                  val appName = getString(L10R.string.app_name) + "-" + getString(L10R.string.suffix)
+                  getColor(R.color.transparent).let { println(it) }
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use L10nR as an import alias here [WrongResourceImportAlias]
+        import slack.l10n.R as L10R
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 3: Replace import alias:
+        @@ -3 +3
+        - import slack.l10n.R as L10R
+        + import slack.l10n.R as L10nR
+        @@ -8 +8
+        -         val appName = getString(L10R.string.app_name) + "-" + getString(L10R.string.suffix)
+        +         val appName = getString(L10nR.string.app_name) + "-" + getString(L10nR.string.suffix)
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `test failure multiple wrong imports`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.uikit.resources.R as SKR
+          import slack.l10n.R as L10R
+
+           class MyClass {
+
+             init {
+                  getColor(SKR.color.transparent).let { println(it) }
+                  val appName = getString(L10R.string.app_name) + "-" + getString(L10R.string.suffix)
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use SlackKitR as an import alias here [WrongResourceImportAlias]
+        import slack.uikit.resources.R as SKR
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 3: Replace import alias:
+        @@ -3 +3
+        - import slack.uikit.resources.R as SKR
+        + import slack.uikit.resources.R as SlackKitR
+        @@ -9 +9
+        -         getColor(SKR.color.transparent).let { println(it) }
+        +         getColor(SlackKitR.color.transparent).let { println(it) }
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `test no fix`() {
+    lint()
+      .files(
+        kotlin(
+          """
+          package slack.pkg.subpackage
+
+          import slack.pkg.subpkg.R as SubPkgR
+
+           class MyClass {
+
+             init {
+                  val appName = getString(SubPkgR.string.app_name)
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `test java no-op`() {
+    lint()
+      .files(
+        java(
+          """
+          package slack.pkg.subpackage;
+
+          import slack.l10n.R;
+
+           class MyClass {
+
+             MyClass() {
+                  String appName = getString(R.string.app_name);
+              }
+
+           }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+}

--- a/slack-lint/src/test/java/slack/lint/resources/WrongResourceImportAliasDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/WrongResourceImportAliasDetectorTest.kt
@@ -36,7 +36,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
           import slack.l10n.R as L10nR
           import slack.pkg.R
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(L10R.string.app_name)
@@ -61,7 +61,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
 
           import slack.l10n.R as L10R
 
-           class MyClass
+          class MyClass
           """
         )
           .indented()
@@ -96,7 +96,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
           import slack.uikit.resources.R as SlackKitR
           import slack.l10n.R as L10R
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(L10R.string.app_name)
@@ -139,7 +139,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
 
           import slack.l10n.R as L10R
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(L10R.string.app_name) + "-" + getString(L10R.string.suffix)
@@ -184,7 +184,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
           import slack.uikit.resources.R as SKR
           import slack.l10n.R as L10R
 
-           class MyClass {
+          class MyClass {
 
              init {
                   getColor(SKR.color.transparent).let { println(it) }
@@ -228,7 +228,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
 
           import slack.pkg.subpkg.R as SubPkgR
 
-           class MyClass {
+          class MyClass {
 
              init {
                   val appName = getString(SubPkgR.string.app_name)
@@ -253,7 +253,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
 
           import slack.l10n.R;
 
-           class MyClass {
+          class MyClass {
 
              MyClass() {
                   String appName = getString(R.string.app_name);

--- a/slack-lint/src/test/java/slack/lint/resources/WrongResourceImportAliasDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/WrongResourceImportAliasDetectorTest.kt
@@ -15,30 +15,29 @@
  */
 package slack.lint.resources
 
-import com.android.tools.lint.checks.infrastructure.TestFile
+import com.android.tools.lint.checks.infrastructure.TestLintTask
 import com.android.tools.lint.detector.api.Detector
 import org.junit.Test
 import slack.lint.BaseSlackLintTest
 
 class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
 
-  private fun propertiesFile(): TestFile.PropertyTestFile = projectProperties().apply {
-    property(
-      ImportAliasesLoader.IMPORT_ALIASES_PROPERTY,
-      "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
-    )
-    to(ImportAliasesLoader.PROPERTY_FILE)
-  }
-
   override fun getDetector(): Detector = WrongResourceImportAliasDetector()
 
   override fun getIssues() = listOf(WrongResourceImportAliasDetector.ISSUE)
+
+  override fun lint(): TestLintTask {
+    return super.lint()
+      .configureOption(
+        ImportAliasesLoader.IMPORT_ALIASES,
+        "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
+      )
+  }
 
   @Test
   fun `test success`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -65,7 +64,6 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure no references`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -100,7 +98,6 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure one reference`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -145,7 +142,6 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure multiple references`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -190,7 +186,6 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure multiple wrong imports`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -236,7 +231,6 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test no fix`() {
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -262,7 +256,6 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test java no-op`() {
     lint()
       .files(
-        propertiesFile(),
         java(
           """
           package slack.pkg.subpackage;

--- a/slack-lint/src/test/java/slack/lint/resources/WrongResourceImportAliasDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/WrongResourceImportAliasDetectorTest.kt
@@ -69,7 +69,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use L10nR as an import alias here [WrongResourceImportAlias]
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Use L10nR as an import alias here [WrongResourceImportAlias]
         import slack.l10n.R as L10R
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -110,7 +110,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:4: Error: Please use L10nR as an import alias here [WrongResourceImportAlias]
+        src/slack/pkg/subpackage/MyClass.kt:4: Error: Use L10nR as an import alias here [WrongResourceImportAlias]
         import slack.l10n.R as L10R
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -154,7 +154,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use L10nR as an import alias here [WrongResourceImportAlias]
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Use L10nR as an import alias here [WrongResourceImportAlias]
         import slack.l10n.R as L10R
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -199,7 +199,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:3: Error: Please use SlackKitR as an import alias here [WrongResourceImportAlias]
+        src/slack/pkg/subpackage/MyClass.kt:3: Error: Use SlackKitR as an import alias here [WrongResourceImportAlias]
         import slack.uikit.resources.R as SKR
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         1 errors, 0 warnings

--- a/slack-lint/src/test/java/slack/lint/resources/WrongResourceImportAliasDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/WrongResourceImportAliasDetectorTest.kt
@@ -15,11 +15,20 @@
  */
 package slack.lint.resources
 
+import com.android.tools.lint.checks.infrastructure.TestFile
 import com.android.tools.lint.detector.api.Detector
 import org.junit.Test
 import slack.lint.BaseSlackLintTest
 
 class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
+
+  private fun propertiesFile(): TestFile.PropertyTestFile = projectProperties().apply {
+      property(
+              ImportAliasesLoader.IMPORT_ALIASES_PROPERTY,
+              "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
+      )
+      to(ImportAliasesLoader.PROPERTY_FILE)
+  }
 
   override fun getDetector(): Detector = WrongResourceImportAliasDetector()
 
@@ -29,6 +38,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test success`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -55,6 +65,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure no references`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -89,6 +100,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure one reference`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -133,6 +145,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure multiple references`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -177,6 +190,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test failure multiple wrong imports`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -222,6 +236,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test no fix`() {
     lint()
       .files(
+        propertiesFile(),
         kotlin(
           """
           package slack.pkg.subpackage
@@ -247,6 +262,7 @@ class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
   fun `test java no-op`() {
     lint()
       .files(
+        propertiesFile(),
         java(
           """
           package slack.pkg.subpackage;

--- a/slack-lint/src/test/java/slack/lint/resources/WrongResourceImportAliasDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/WrongResourceImportAliasDetectorTest.kt
@@ -23,11 +23,11 @@ import slack.lint.BaseSlackLintTest
 class WrongResourceImportAliasDetectorTest : BaseSlackLintTest() {
 
   private fun propertiesFile(): TestFile.PropertyTestFile = projectProperties().apply {
-      property(
-              ImportAliasesLoader.IMPORT_ALIASES_PROPERTY,
-              "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
-      )
-      to(ImportAliasesLoader.PROPERTY_FILE)
+    property(
+      ImportAliasesLoader.IMPORT_ALIASES_PROPERTY,
+      "slack.l10n.R as L10nR, slack.uikit.resources.R as SlackKitR, slack.uikit.R as UiKitR"
+    )
+    to(ImportAliasesLoader.PROPERTY_FILE)
   }
 
   override fun getDetector(): Detector = WrongResourceImportAliasDetector()


### PR DESCRIPTION
This adds 3 lint checks that enforce the rules around referencing resources in a non-transitive R class world:

- [MissingResourceImportAliasDetector](https://github.com/slackhq/slack-lints/commit/c94bb42e8bfb3c7fc42581da9d9fca78c2077308) : enforces that only the local module's R class can be imported without an import alias.
- [WrongResourceImportAliasDetector](https://github.com/slackhq/slack-lints/commit/90a0d2dc20ff21268d3676e3f0ff2723a9269f0b): enforces that the import aliases for R classes are consistent across the codebase.
- [FullyQualifiedResourceDetector](https://github.com/slackhq/slack-lints/commit/17dbcc04c02ee3ade8872964ba01f82f213c82f6): enforces that R classes aren't referenced using their fully qualified names.

Best reviewed by commit.

| MissingResourceImportAliasDetector | WrongResourceImportAliasDetector | FullyQualifiedResourceDetector |
| ----------- | ----------- | ----------- |
| <video src="https://user-images.githubusercontent.com/3355288/192290006-883e21c3-5440-4b85-a2fe-b751c233c03c.mp4"/> | <video src="https://user-images.githubusercontent.com/3355288/192290055-d310cbd0-345a-4844-9199-bdb937790d5b.mp4"/>  | <video src="https://user-images.githubusercontent.com/3355288/192290213-5c8875bf-1cfd-4510-a7a4-a4772ac80d75.mp4"/> |


