### PR TITLE
Use StringOption for inclusive naming lint

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ dokka = { id = "org.jetbrains.dokka", version = "1.6.10" }
 lint = { id = "com.android.lint", version = "7.2.0" }
 ksp = { id = "com.google.devtools.ksp", version = "1.6.21-1.0.5" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.19.0" }
-spotless = { id = "com.diffplug.spotless", version = "6.3.0" }
+spotless = { id = "com.diffplug.spotless", version = "6.11.0" }
 
 [libraries]
 autoService-annotations = "com.google.auto.service:auto-service-annotations:1.0"

--- a/slack-lint/src/main/java/slack/lint/inclusive/InclusiveNamingChecker.kt
+++ b/slack-lint/src/main/java/slack/lint/inclusive/InclusiveNamingChecker.kt
@@ -41,7 +41,7 @@ sealed class InclusiveNamingChecker<C : Context, N> {
     internal val BLOCK_LIST =
       StringOption(
         "block-list",
-        "A comma-separated list of blocked words from [BLOCK_LIST_PROPERTY] set in the root project's`.",
+        "A comma-separated list of words that should not be used in source code.",
         null,
         "This property should define a comma-separated list of words that should not be used in source code."
       )

--- a/slack-lint/src/test/java/slack/lint/inclusive/InclusiveNamingDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/inclusive/InclusiveNamingDetectorTest.kt
@@ -15,23 +15,29 @@
  */
 package slack.lint.inclusive
 
-import com.android.tools.lint.checks.infrastructure.TestFile.PropertyTestFile
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import com.android.tools.lint.checks.infrastructure.TestMode
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Issue
 import org.junit.Ignore
 import org.junit.Test
 import slack.lint.BaseSlackLintTest
 
-@Suppress("UnstableApiUsage")
 class InclusiveNamingDetectorTest : BaseSlackLintTest() {
-
-  private fun propertiesFile(): PropertyTestFile = projectProperties().apply {
-    property(InclusiveNamingChecker.BLOCK_LIST_PROPERTY, "fork,knife,spoon,spork")
-    to(InclusiveNamingChecker.PROPERTY_FILE)
-  }
 
   override fun getDetector(): Detector = InclusiveNamingSourceCodeScanner()
   override fun getIssues(): List<Issue> = InclusiveNamingChecker.ISSUES.toList()
+
+  override fun lint(): TestLintTask {
+    return super.lint()
+      .configureOption(InclusiveNamingChecker.BLOCK_LIST, "fork,knife,spoon,spork")
+  }
+
+  override val skipTestModes: Array<TestMode> = arrayOf(
+    // Aliases are impossible to test correctly because you have to maintain completely different
+    // expected fixes and source inputs
+    TestMode.TYPE_ALIAS,
+  )
 
   @Test
   fun kotlin() {
@@ -44,7 +50,6 @@ class InclusiveNamingDetectorTest : BaseSlackLintTest() {
     // - Function
     lint()
       .files(
-        propertiesFile(),
         kotlin(
           "test/ForkHandler.kt",
           """
@@ -113,7 +118,6 @@ class InclusiveNamingDetectorTest : BaseSlackLintTest() {
     // - Method
     lint()
       .files(
-        propertiesFile(),
         java(
           "test/ForkHandler.java",
           """
@@ -159,7 +163,6 @@ class InclusiveNamingDetectorTest : BaseSlackLintTest() {
     // Attr
     lint()
       .files(
-        propertiesFile(),
         xml(
           "test_file.xml",
           """


### PR DESCRIPTION
I found a vague reference in the sample lint config on [this doc page](http://googlesamples.github.io/android-custom-lint-rules/usage/lintxml.md.html#configuringusinglint.xmlfiles/xmlsyntax) that took me down a path to finding there's a new options API in lint for configuring lint detectors via the standard lint xml config.

This updates the inclusive naming linter to use that pattern, so now we would add this entry to our `lint.xml` to configure this instead. Much nicer 👍.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<lint>
    <issue id="InclusiveNaming">
        <option name="block-list" value="fork,knife,spoon,spork"/>
    </issue>
</lint>

```