### PR TITLE
Fix non-transitive R class lints

### DIFF
--- a/slack-lint/src/main/java/slack/lint/resources/FullyQualifiedResourceDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/FullyQualifiedResourceDetector.kt
@@ -79,7 +79,7 @@ class FullyQualifiedResourceDetector : Detector(), SourceCodeScanner {
           // Alternative to ReplaceStringBuilder#imports since that one didn't work here.
           addImportIfMissing(qualifier, alias, fixes)
 
-          fix().name("Replace import alias").composite(
+          fix().name("Replace with import alias").composite(
             *fixes.reversed().toTypedArray()
           ).autoFix()
         } else {

--- a/slack-lint/src/main/java/slack/lint/resources/MissingResourceImportAliasDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/resources/MissingResourceImportAliasDetector.kt
@@ -28,7 +28,6 @@ import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UImportStatement
 import org.jetbrains.uast.USimpleNameReferenceExpression
-import org.jetbrains.uast.getContainingUFile
 import org.jetbrains.uast.getQualifiedParentOrThis
 import slack.lint.resources.ImportAliasesLoader.IMPORT_ALIASES
 import slack.lint.resources.model.RootIssueData
@@ -79,12 +78,12 @@ class MissingResourceImportAliasDetector : Detector(), SourceCodeScanner {
         val importDirective = node.sourcePsi as? KtImportDirective ?: return
 
         if (importDirective.importedName?.identifier == "R" && importDirective.aliasName == null) {
-          val packageName = node.getContainingUFile()?.packageName ?: return
+          val packageName = context.project.`package` ?: return
 
           val importedFqName = importDirective.importedFqName
           val parentImportedFqName = importedFqName?.parent()?.asString()
 
-          val isLocalResourceImport = parentImportedFqName?.let { packageName.startsWith(it) } ?: true
+          val isLocalResourceImport = parentImportedFqName?.let { it == packageName } ?: true
           if (!isLocalResourceImport) {
             val importedFqNameString = requireNotNull(importedFqName).asString()
             val alias = importAliases[importedFqNameString]

--- a/slack-lint/src/test/java/slack/lint/resources/FullyQualifiedResourceDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/FullyQualifiedResourceDetectorTest.kt
@@ -89,7 +89,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
       )
       .expectFixDiffs(
         """
-        Autofix for src/slack/pkg/subpackage/MyClass.kt line 6: Replace import alias:
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 6: Replace with import alias:
         @@ -3 +3
         + import slack.l10n.R as L10nR
         +
@@ -132,7 +132,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
       )
       .expectFixDiffs(
         """
-        Autofix for src/slack/pkg/subpackage/MyClass.kt line 8: Replace import alias:
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 8: Replace with import alias:
         @@ -4 +4
         + import slack.l10n.R as L10nR
         @@ -8 +9
@@ -175,7 +175,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
       )
       .expectFixDiffs(
         """
-        Autofix for src/slack/pkg/subpackage/MyClass.kt line 9: Replace import alias:
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 9: Replace with import alias:
         @@ -9 +9
         -         val appName = getString(slack.l10n.R.string.app_name)
         +         val appName = getString(L10nR.string.app_name)
@@ -215,7 +215,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
       )
       .expectFixDiffs(
         """
-        Autofix for src/slack/pkg/subpackage/MyClass.kt line 8: Replace import alias:
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 8: Replace with import alias:
         @@ -4 +4
         + import slack.l10n.R as L10nR
         @@ -8 +9
@@ -257,7 +257,7 @@ class FullyQualifiedResourceDetectorTest : BaseSlackLintTest() {
       )
       .expectFixDiffs(
         """
-        Autofix for src/slack/pkg/subpackage/MyClass.kt line 8: Replace import alias:
+        Autofix for src/slack/pkg/subpackage/MyClass.kt line 8: Replace with import alias:
         @@ -4 +4
         + import slack.l10n.R as L10nR
         @@ -8 +9

--- a/slack-lint/src/test/java/slack/lint/resources/MissingResourceImportAliasDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/resources/MissingResourceImportAliasDetectorTest.kt
@@ -40,10 +40,10 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .files(
         kotlin(
           """
-          package slack.pkg.subpackage
+          package lint.test.pkg.subpackage
 
           import slack.l10n.R as L10nR
-          import slack.pkg.R
+          import lint.test.pkg.R
 
           class MyClass {
 
@@ -66,7 +66,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .files(
         kotlin(
           """
-          package slack.pkg.subpackage
+          package lint.test.pkg
 
           import slack.l10n.R
 
@@ -78,7 +78,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
+        src/lint/test/pkg/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
         import slack.l10n.R
         ~~~~~~~~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -86,7 +86,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       )
       .expectFixDiffs(
         """
-        Autofix for src/slack/pkg/subpackage/MyClass.kt line 3: Add import alias:
+        Autofix for src/lint/test/pkg/MyClass.kt line 3: Add import alias:
         @@ -3 +3
         - import slack.l10n.R
         + import slack.l10n.R as L10nR
@@ -100,7 +100,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .files(
         kotlin(
           """
-          package slack.pkg.subpackage
+          package lint.test.pkg
 
           import slack.l10n.R
 
@@ -118,7 +118,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
+        src/lint/test/pkg/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
         import slack.l10n.R
         ~~~~~~~~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -126,7 +126,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       )
       .expectFixDiffs(
         """
-        Autofix for src/slack/pkg/subpackage/MyClass.kt line 3: Add import alias:
+        Autofix for src/lint/test/pkg/MyClass.kt line 3: Add import alias:
         @@ -3 +3
         - import slack.l10n.R
         + import slack.l10n.R as L10nR
@@ -143,7 +143,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .files(
         kotlin(
           """
-          package slack.pkg.subpackage
+          package lint.test.pkg
 
           import slack.l10n.R
 
@@ -162,7 +162,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
+        src/lint/test/pkg/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
         import slack.l10n.R
         ~~~~~~~~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -170,7 +170,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       )
       .expectFixDiffs(
         """
-        Autofix for src/slack/pkg/subpackage/MyClass.kt line 3: Add import alias:
+        Autofix for src/lint/test/pkg/MyClass.kt line 3: Add import alias:
         @@ -3 +3
         - import slack.l10n.R
         + import slack.l10n.R as L10nR
@@ -189,7 +189,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .files(
         kotlin(
           """
-          package slack.pkg.subpackage
+          package lint.test.pkg
 
           import slack.l10n.R
 
@@ -210,7 +210,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
+        src/lint/test/pkg/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
         import slack.l10n.R
         ~~~~~~~~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -218,7 +218,7 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       )
       .expectFixDiffs(
         """
-        Autofix for src/slack/pkg/subpackage/MyClass.kt line 3: Add import alias:
+        Autofix for src/lint/test/pkg/MyClass.kt line 3: Add import alias:
         @@ -3 +3
         - import slack.l10n.R
         + import slack.l10n.R as L10nR
@@ -238,9 +238,9 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .files(
         kotlin(
           """
-          package slack.pkg.subpackage
+          package lint.test.pkg
 
-          import slack.pkg.subpkg.R
+          import lint.test.subpkg.R
 
           class MyClass {
 
@@ -256,8 +256,8 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/slack/pkg/subpackage/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
-        import slack.pkg.subpkg.R
+        src/lint/test/pkg/MyClass.kt:3: Error: Use an import alias for R classes from other modules [MissingResourceImportAlias]
+        import lint.test.subpkg.R
         ~~~~~~~~~~~~~~~~~~~~~~~~~
         1 errors, 0 warnings
         """.trimIndent()
@@ -271,9 +271,9 @@ class MissingResourceImportAliasDetectorTest : BaseSlackLintTest() {
       .files(
         java(
           """
-          package slack.pkg.subpackage;
+          package lint.test.pkg;
 
-          import slack.pkg.subpkg.R;
+          import lint.test.subpkg.R;
 
           class MyClass {
 


### PR DESCRIPTION
This updates `MissingResourceImportAliasDetector` to use the module's package name instead of the file's to avoid false positives for modules with custom namespaces. It also updates the fix name for `FullyQualifiedResourceDetector`.
