### PR TITLE
Fix compose lint explanation strings

### DIFF
--- a/slack-lint-checks/lint-baseline.xml
+++ b/slack-lint-checks/lint-baseline.xml
@@ -47,6 +47,50 @@
 
     <issue
         id="LintImplTextFormat"
+        message="Multi-line issue explanation strings will interpret line separators as hard breaks, and this looks like a continuation of the same paragraph. Consider using \ at the end of the previous line to indicate that the lines should be joined, or add a blank line between unrelated sentences, or suppress this issue type here."
+        errorLine1="            Composable functions should either emit content into the composition or return a value, but not both."
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/compose/ComposeContentEmitterReturningValuesDetector.kt"
+            line="42"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="LintImplTextFormat"
+        message="Multi-line issue explanation strings will interpret line separators as hard breaks, and this looks like a continuation of the same paragraph. Consider using \ at the end of the previous line to indicate that the lines should be joined, or add a blank line between unrelated sentences, or suppress this issue type here."
+        errorLine1="              Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app."
+        errorLine2="              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/compose/ComposeMutableParametersDetector.kt"
+            line="24"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="LintImplTextFormat"
+        message="Multi-line issue explanation strings will interpret line separators as hard breaks, and this looks like a continuation of the same paragraph. Consider using \ at the end of the previous line to indicate that the lines should be joined, or add a blank line between unrelated sentences, or suppress this issue type here."
+        errorLine1="              Composable functions that return Unit should start with an uppercase letter."
+        errorLine2="              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/compose/ComposeNamingDetector.kt"
+            line="40"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="LintImplTextFormat"
+        message="Multi-line issue explanation strings will interpret line separators as hard breaks, and this looks like a continuation of the same paragraph. Consider using \ at the end of the previous line to indicate that the lines should be joined, or add a blank line between unrelated sentences, or suppress this issue type here."
+        errorLine1="              Composable functions that return a value should start with a lowercase letter."
+        errorLine2="              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/slack/lint/compose/ComposeNamingDetector.kt"
+            line="58"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="LintImplTextFormat"
         message="The issue summary should *not* end with a period (think of it as a headline)"
         errorLine1="        &quot;@Binds-annotated functions can be extension functions.&quot;,"
         errorLine2="         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
@@ -538,127 +582,6 @@
             file="src/main/java/slack/lint/resources/WrongResourceImportAliasDetector.kt"
             line="130"
             column="38"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimIndent()` in issue registration strings; they are already trimmed by indent by lint when displaying to users"
-        errorLine1="              .trimIndent(),"
-        errorLine2="               ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/slack/lint/compose/ComposeCompositionLocalNamingDetector.kt"
-            line="44"
-            column="16"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimIndent()` in issue registration strings; they are already trimmed by indent by lint when displaying to users"
-        errorLine1="              .trimIndent(),"
-        errorLine2="               ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/slack/lint/compose/ComposeCompositionLocalUsageDetector.kt"
-            line="44"
-            column="16"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimIndent()` in issue registration strings; they are already trimmed by indent by lint when displaying to users"
-        errorLine1="              .trimIndent(),"
-        errorLine2="               ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/slack/lint/compose/ComposeContentEmitterReturningValuesDetector.kt"
-            line="47"
-            column="16"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimIndent()` in issue registration strings; they are already trimmed by indent by lint when displaying to users"
-        errorLine1="              .trimIndent(),"
-        errorLine2="               ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/slack/lint/compose/ComposeModifierMissingDetector.kt"
-            line="43"
-            column="16"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimIndent()` in issue registration strings; they are already trimmed by indent by lint when displaying to users"
-        errorLine1="              .trimIndent(),"
-        errorLine2="               ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/slack/lint/compose/ComposeModifierReusedDetector.kt"
-            line="50"
-            column="16"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimIndent()` in issue registration strings; they are already trimmed by indent by lint when displaying to users"
-        errorLine1="            .trimIndent(),"
-        errorLine2="             ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/slack/lint/compose/ComposeModifierWithoutDefaultDetector.kt"
-            line="35"
-            column="14"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimIndent()` in issue registration strings; they are already trimmed by indent by lint when displaying to users"
-        errorLine1="              .trimIndent(),"
-        errorLine2="               ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/slack/lint/compose/ComposeMultipleContentEmittersDetector.kt"
-            line="46"
-            column="16"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimIndent()` in issue registration strings; they are already trimmed by indent by lint when displaying to users"
-        errorLine1="            .trimIndent(),"
-        errorLine2="             ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/slack/lint/compose/ComposeMutableParametersDetector.kt"
-            line="29"
-            column="14"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimIndent()` in issue registration strings; they are already trimmed by indent by lint when displaying to users"
-        errorLine1="              .trimIndent(),"
-        errorLine2="               ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/slack/lint/compose/ComposeNamingDetector.kt"
-            line="45"
-            column="16"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimIndent()` in issue registration strings; they are already trimmed by indent by lint when displaying to users"
-        errorLine1="              .trimIndent(),"
-        errorLine2="               ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/slack/lint/compose/ComposeNamingDetector.kt"
-            line="64"
-            column="16"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimIndent()` in issue registration strings; they are already trimmed by indent by lint when displaying to users"
-        errorLine1="              .trimIndent(),"
-        errorLine2="               ~~~~~~~~~~~~">
-        <location
-            file="src/main/java/slack/lint/compose/ComposePreviewPublicDetector.kt"
-            line="50"
-            column="16"/>
     </issue>
 
     <issue

--- a/slack-lint-checks/src/main/java/slack/lint/SlackIssueRegistry.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/SlackIssueRegistry.kt
@@ -78,20 +78,20 @@ class SlackIssueRegistry : IssueRegistry() {
       WrongResourceImportAliasDetector.ISSUE,
       DenyListedApiDetector.ISSUE,
       // <editor-fold desc="Compose Detectors">
-      ComposeCompositionLocalUsageDetector.ISSUE,
+      *ComposeNamingDetector.ISSUES,
       ComposeCompositionLocalNamingDetector.ISSUE,
+      ComposeCompositionLocalUsageDetector.ISSUE,
       ComposeContentEmitterReturningValuesDetector.ISSUE,
       ComposeModifierMissingDetector.ISSUE,
-      *ComposeNamingDetector.ISSUES,
       ComposeModifierReusedDetector.ISSUE,
       ComposeModifierWithoutDefaultDetector.ISSUE,
-      ComposeParameterOrderDetector.ISSUE,
-      ComposeRememberMissingDetector.ISSUE,
       ComposeMultipleContentEmittersDetector.ISSUE,
-      ComposeUnstableCollectionsDetector.ISSUE,
       ComposeMutableParametersDetector.ISSUE,
+      ComposeParameterOrderDetector.ISSUE,
       ComposePreviewNamingDetector.ISSUE,
       ComposePreviewPublicDetector.ISSUE,
+      ComposeRememberMissingDetector.ISSUE,
+      ComposeUnstableCollectionsDetector.ISSUE,
       // </editor-fold>
     )
 }

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalNamingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalNamingDetector.kt
@@ -37,11 +37,10 @@ class ComposeCompositionLocalNamingDetector : Detector(), SourceCodeScanner {
           briefDescription = "CompositionLocals should be named using the `Local` prefix",
           explanation =
             """
-                  `CompositionLocals` should be named using the `Local` prefix as an adjective, followed by a descriptive noun. \
-                   \
-                  See https://twitter.github.io/compose-rules/rules/#naming-compositionlocals-properly for more information.
-              """
-              .trimIndent(),
+              `CompositionLocals` should be named using the `Local` prefix as an adjective, followed by a descriptive noun.
+              
+              See https://twitter.github.io/compose-rules/rules/#naming-compositionlocals-properly for more information.
+            """,
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalNamingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalNamingDetector.kt
@@ -38,7 +38,6 @@ class ComposeCompositionLocalNamingDetector : Detector(), SourceCodeScanner {
           explanation =
             """
               `CompositionLocals` should be named using the `Local` prefix as an adjective, followed by a descriptive noun.
-
               See https://twitter.github.io/compose-rules/rules/#naming-compositionlocals-properly for more information.
             """,
           category = Category.PRODUCTIVITY,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalNamingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalNamingDetector.kt
@@ -37,8 +37,8 @@ class ComposeCompositionLocalNamingDetector : Detector(), SourceCodeScanner {
           briefDescription = "CompositionLocals should be named using the `Local` prefix",
           explanation =
             """
-                  `CompositionLocals` should be named using the `Local` prefix as an adjective, followed by a descriptive noun.\
-                  \
+                  `CompositionLocals` should be named using the `Local` prefix as an adjective, followed by a descriptive noun. \
+                   \
                   See https://twitter.github.io/compose-rules/rules/#naming-compositionlocals-properly for more information.
               """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalNamingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalNamingDetector.kt
@@ -38,7 +38,7 @@ class ComposeCompositionLocalNamingDetector : Detector(), SourceCodeScanner {
           explanation =
             """
               `CompositionLocals` should be named using the `Local` prefix as an adjective, followed by a descriptive noun.
-              
+
               See https://twitter.github.io/compose-rules/rules/#naming-compositionlocals-properly for more information.
             """,
           category = Category.PRODUCTIVITY,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalUsageDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalUsageDetector.kt
@@ -37,8 +37,8 @@ class ComposeCompositionLocalUsageDetector : Detector(), SourceCodeScanner {
           briefDescription = "CompositionLocals are discouraged",
           explanation =
             """
-                  `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.\
-                  \
+                  `CompositionLocal`s are implicit dependencies and creating new ones should be avoided. \
+                   \
                   See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information.
               """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalUsageDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalUsageDetector.kt
@@ -37,8 +37,8 @@ class ComposeCompositionLocalUsageDetector : Detector(), SourceCodeScanner {
           briefDescription = "CompositionLocals are discouraged",
           explanation =
             """
-                  `CompositionLocal`s are implicit dependencies and creating new ones should be avoided. \
-                   \
+                  `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
+                  
                   See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information.
               """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalUsageDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalUsageDetector.kt
@@ -37,10 +37,9 @@ class ComposeCompositionLocalUsageDetector : Detector(), SourceCodeScanner {
           briefDescription = "CompositionLocals are discouraged",
           explanation =
             """
-                  `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
-
-                  See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information.
-              """,
+              `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
+              See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information.
+            """,
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalUsageDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeCompositionLocalUsageDetector.kt
@@ -38,10 +38,9 @@ class ComposeCompositionLocalUsageDetector : Detector(), SourceCodeScanner {
           explanation =
             """
                   `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
-                  
+
                   See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information.
-              """
-              .trimIndent(),
+              """,
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeContentEmitterReturningValuesDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeContentEmitterReturningValuesDetector.kt
@@ -39,9 +39,9 @@ constructor(
           briefDescription = "Composable functions should emit XOR return",
           explanation =
             """
-            Composable functions should either emit content into the composition or return a value, but not both. \
-            If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller. \
-             \
+            Composable functions should either emit content into the composition or return a value, but not both.
+            If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
+            
             See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information.
         """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeContentEmitterReturningValuesDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeContentEmitterReturningValuesDetector.kt
@@ -41,7 +41,6 @@ constructor(
             """
             Composable functions should either emit content into the composition or return a value, but not both.
             If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
-
             See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information.
         """,
           category = Category.PRODUCTIVITY,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeContentEmitterReturningValuesDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeContentEmitterReturningValuesDetector.kt
@@ -41,10 +41,9 @@ constructor(
             """
             Composable functions should either emit content into the composition or return a value, but not both.
             If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
-            
+
             See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information.
-        """
-              .trimIndent(),
+        """,
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeContentEmitterReturningValuesDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeContentEmitterReturningValuesDetector.kt
@@ -39,9 +39,9 @@ constructor(
           briefDescription = "Composable functions should emit XOR return",
           explanation =
             """
-            Composable functions should either emit content into the composition or return a value, but not both.\
-            If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.\
-            \
+            Composable functions should either emit content into the composition or return a value, but not both. \
+            If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller. \
+             \
             See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information.
         """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierMissingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierMissingDetector.kt
@@ -36,8 +36,8 @@ constructor(
           briefDescription = "Missing modifier parameter",
           explanation =
             """
-              This @Composable function emits content but doesn't have a modifier parameter. \
-               \
+              This @Composable function emits content but doesn't have a modifier parameter.
+              
               See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information.
             """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierMissingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierMissingDetector.kt
@@ -37,10 +37,9 @@ constructor(
           explanation =
             """
               This @Composable function emits content but doesn't have a modifier parameter.
-              
+
               See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information.
-            """
-              .trimIndent(),
+            """,
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierMissingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierMissingDetector.kt
@@ -36,8 +36,8 @@ constructor(
           briefDescription = "Missing modifier parameter",
           explanation =
             """
-              This @Composable function emits content but doesn't have a modifier parameter.\
-              \
+              This @Composable function emits content but doesn't have a modifier parameter. \
+               \
               See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information.
             """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierMissingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierMissingDetector.kt
@@ -37,7 +37,6 @@ constructor(
           explanation =
             """
               This @Composable function emits content but doesn't have a modifier parameter.
-
               See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information.
             """,
           category = Category.PRODUCTIVITY,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierReusedDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierReusedDetector.kt
@@ -42,12 +42,11 @@ constructor(
           explanation =
             """
               Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. `modifier.fillMaxWidth()`.
-              
+
               Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-              
+
               See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information.
-            """
-              .trimIndent(),
+            """,
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierReusedDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierReusedDetector.kt
@@ -41,10 +41,10 @@ constructor(
           briefDescription = "Modifiers should only be used once",
           explanation =
             """
-              Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. `modifier.fillMaxWidth()`.\
-              \
-              Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.\
-              \
+              Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. `modifier.fillMaxWidth()`. \
+               \
+              Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables. \
+               \
               See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information.
             """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierReusedDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierReusedDetector.kt
@@ -42,9 +42,7 @@ constructor(
           explanation =
             """
               Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. `modifier.fillMaxWidth()`.
-
               Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
               See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information.
             """,
           category = Category.PRODUCTIVITY,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierReusedDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierReusedDetector.kt
@@ -41,10 +41,10 @@ constructor(
           briefDescription = "Modifiers should only be used once",
           explanation =
             """
-              Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. `modifier.fillMaxWidth()`. \
-               \
-              Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables. \
-               \
+              Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. `modifier.fillMaxWidth()`.
+              
+              Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+              
               See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information.
             """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierWithoutDefaultDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierWithoutDefaultDetector.kt
@@ -29,7 +29,6 @@ class ComposeModifierWithoutDefaultDetector : ComposableFunctionDetector(), Sour
         explanation =
           """
               This @Composable function has a modifier parameter but it doesn't have a default value.
-
               See https://twitter.github.io/compose-rules/rules/#modifiers-should-have-default-parameters for more information.
             """,
         category = Category.PRODUCTIVITY,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierWithoutDefaultDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierWithoutDefaultDetector.kt
@@ -28,8 +28,8 @@ class ComposeModifierWithoutDefaultDetector : ComposableFunctionDetector(), Sour
         briefDescription = "Missing Modifier default value",
         explanation =
           """
-              This @Composable function has a modifier parameter but it doesn't have a default value.\
-              \
+              This @Composable function has a modifier parameter but it doesn't have a default value. \
+               \
               See https://twitter.github.io/compose-rules/rules/#modifiers-should-have-default-parameters for more information.
             """
             .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierWithoutDefaultDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierWithoutDefaultDetector.kt
@@ -28,8 +28,8 @@ class ComposeModifierWithoutDefaultDetector : ComposableFunctionDetector(), Sour
         briefDescription = "Missing Modifier default value",
         explanation =
           """
-              This @Composable function has a modifier parameter but it doesn't have a default value. \
-               \
+              This @Composable function has a modifier parameter but it doesn't have a default value.
+              
               See https://twitter.github.io/compose-rules/rules/#modifiers-should-have-default-parameters for more information.
             """
             .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierWithoutDefaultDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeModifierWithoutDefaultDetector.kt
@@ -29,10 +29,9 @@ class ComposeModifierWithoutDefaultDetector : ComposableFunctionDetector(), Sour
         explanation =
           """
               This @Composable function has a modifier parameter but it doesn't have a default value.
-              
+
               See https://twitter.github.io/compose-rules/rules/#modifiers-should-have-default-parameters for more information.
-            """
-            .trimIndent(),
+            """,
         category = Category.PRODUCTIVITY,
         priority = Priorities.NORMAL,
         severity = Severity.ERROR,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMultipleContentEmittersDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMultipleContentEmittersDetector.kt
@@ -40,10 +40,9 @@ constructor(
           explanation =
             """
             Composable functions should only be emitting content into the composition from one source at their top level.
-            
+
             See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information.
-        """
-              .trimIndent(),
+        """,
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMultipleContentEmittersDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMultipleContentEmittersDetector.kt
@@ -39,8 +39,8 @@ constructor(
           briefDescription = "Composables should only be emit from one source",
           explanation =
             """
-            Composable functions should only be emitting content into the composition from one source at their top level.\
-            \
+            Composable functions should only be emitting content into the composition from one source at their top level. \
+             \
             See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information.
         """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMultipleContentEmittersDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMultipleContentEmittersDetector.kt
@@ -39,8 +39,8 @@ constructor(
           briefDescription = "Composables should only be emit from one source",
           explanation =
             """
-            Composable functions should only be emitting content into the composition from one source at their top level. \
-             \
+            Composable functions should only be emitting content into the composition from one source at their top level.
+            
             See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information.
         """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMultipleContentEmittersDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMultipleContentEmittersDetector.kt
@@ -39,10 +39,9 @@ constructor(
           briefDescription = "Composables should only be emit from one source",
           explanation =
             """
-            Composable functions should only be emitting content into the composition from one source at their top level.
-
-            See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information.
-        """,
+              Composable functions should only be emitting content into the composition from one source at their top level.
+              See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information.
+            """,
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMutableParametersDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMutableParametersDetector.kt
@@ -21,9 +21,9 @@ class ComposeMutableParametersDetector : ComposableFunctionDetector(), SourceCod
         briefDescription = "Mutable objects in Compose will break state",
         explanation =
           """
-              Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.\
-              Mutable objects that are not observable, such as `ArrayList<T>` or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.\
-              \
+              Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app. \
+              Mutable objects that are not observable, such as `ArrayList<T>` or a mutable data class, cannot be observed by Compose to trigger recomposition when they change. \
+               \
               See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information.
             """
             .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMutableParametersDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMutableParametersDetector.kt
@@ -23,10 +23,9 @@ class ComposeMutableParametersDetector : ComposableFunctionDetector(), SourceCod
           """
               Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
               Mutable objects that are not observable, such as `ArrayList<T>` or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
-              
+
               See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information.
-            """
-            .trimIndent(),
+            """,
         category = Category.PRODUCTIVITY,
         priority = Priorities.NORMAL,
         severity = Severity.ERROR,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMutableParametersDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMutableParametersDetector.kt
@@ -21,9 +21,9 @@ class ComposeMutableParametersDetector : ComposableFunctionDetector(), SourceCod
         briefDescription = "Mutable objects in Compose will break state",
         explanation =
           """
-              Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app. \
-              Mutable objects that are not observable, such as `ArrayList<T>` or a mutable data class, cannot be observed by Compose to trigger recomposition when they change. \
-               \
+              Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
+              Mutable objects that are not observable, such as `ArrayList<T>` or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
+              
               See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information.
             """
             .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMutableParametersDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeMutableParametersDetector.kt
@@ -23,7 +23,6 @@ class ComposeMutableParametersDetector : ComposableFunctionDetector(), SourceCod
           """
               Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
               Mutable objects that are not observable, such as `ArrayList<T>` or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
-
               See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information.
             """,
         category = Category.PRODUCTIVITY,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeNamingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeNamingDetector.kt
@@ -37,9 +37,9 @@ constructor(
           briefDescription = "Unit Composables should be uppercase",
           explanation =
             """
-              Composable functions that return Unit should start with an uppercase letter.\
-              They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.\
-              \
+              Composable functions that return Unit should start with an uppercase letter.  \
+              They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes. \
+               \
               See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information.
             """
               .trimIndent(),
@@ -56,9 +56,9 @@ constructor(
           briefDescription = "Value-returning Composables should be lowercase",
           explanation =
             """
-              Composable functions that return a value should start with a lowercase letter.\
-              While useful and accepted outside of @Composable functions, this factory function convention has drawbacks that set inappropriate expectations for callers when used with @Composable functions.\
-              \
+              Composable functions that return a value should start with a lowercase letter. \
+              While useful and accepted outside of @Composable functions, this factory function convention has drawbacks that set inappropriate expectations for callers when used with @Composable functions. \
+               \
               See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information.
             """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeNamingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeNamingDetector.kt
@@ -39,7 +39,6 @@ constructor(
             """
               Composable functions that return Unit should start with an uppercase letter.
               They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.
-
               See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information.
             """,
           category = Category.PRODUCTIVITY,
@@ -57,7 +56,6 @@ constructor(
             """
               Composable functions that return a value should start with a lowercase letter.
               While useful and accepted outside of @Composable functions, this factory function convention has drawbacks that set inappropriate expectations for callers when used with @Composable functions.
-
               See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information.
             """,
           category = Category.PRODUCTIVITY,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeNamingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeNamingDetector.kt
@@ -37,9 +37,9 @@ constructor(
           briefDescription = "Unit Composables should be uppercase",
           explanation =
             """
-              Composable functions that return Unit should start with an uppercase letter.  \
-              They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes. \
-               \
+              Composable functions that return Unit should start with an uppercase letter. 
+              They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.
+              
               See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information.
             """
               .trimIndent(),
@@ -56,9 +56,9 @@ constructor(
           briefDescription = "Value-returning Composables should be lowercase",
           explanation =
             """
-              Composable functions that return a value should start with a lowercase letter. \
-              While useful and accepted outside of @Composable functions, this factory function convention has drawbacks that set inappropriate expectations for callers when used with @Composable functions. \
-               \
+              Composable functions that return a value should start with a lowercase letter.
+              While useful and accepted outside of @Composable functions, this factory function convention has drawbacks that set inappropriate expectations for callers when used with @Composable functions.
+              
               See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information.
             """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeNamingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeNamingDetector.kt
@@ -37,12 +37,11 @@ constructor(
           briefDescription = "Unit Composables should be uppercase",
           explanation =
             """
-              Composable functions that return Unit should start with an uppercase letter. 
+              Composable functions that return Unit should start with an uppercase letter.
               They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.
-              
+
               See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information.
-            """
-              .trimIndent(),
+            """,
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,
@@ -58,10 +57,9 @@ constructor(
             """
               Composable functions that return a value should start with a lowercase letter.
               While useful and accepted outside of @Composable functions, this factory function convention has drawbacks that set inappropriate expectations for callers when used with @Composable functions.
-              
+
               See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information.
-            """
-              .trimIndent(),
+            """,
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeParameterOrderDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeParameterOrderDetector.kt
@@ -29,11 +29,11 @@ class ComposeParameterOrderDetector : ComposableFunctionDetector(), SourceCodeSc
 
     fun createErrorMessage(currentOrder: String, properOrder: String): String =
       """
-            Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
-            Current params are: [$currentOrder] but should be [$properOrder].
-            
-            See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information.
-        """
+        Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+        Current params are: [$currentOrder] but should be [$properOrder].
+
+        See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information.
+      """
         .trimIndent()
 
     val ISSUE =

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeParameterOrderDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeParameterOrderDetector.kt
@@ -29,9 +29,9 @@ class ComposeParameterOrderDetector : ComposableFunctionDetector(), SourceCodeSc
 
     fun createErrorMessage(currentOrder: String, properOrder: String): String =
       """
-            Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.\
-            Current params are: [$currentOrder] but should be [$properOrder].\
-            \
+            Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param. \
+            Current params are: [$currentOrder] but should be [$properOrder]. \
+             \
             See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information.
         """
         .trimIndent()

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeParameterOrderDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeParameterOrderDetector.kt
@@ -29,9 +29,9 @@ class ComposeParameterOrderDetector : ComposableFunctionDetector(), SourceCodeSc
 
     fun createErrorMessage(currentOrder: String, properOrder: String): String =
       """
-            Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param. \
-            Current params are: [$currentOrder] but should be [$properOrder]. \
-             \
+            Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+            Current params are: [$currentOrder] but should be [$properOrder].
+            
             See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information.
         """
         .trimIndent()

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeParameterOrderDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeParameterOrderDetector.kt
@@ -31,7 +31,6 @@ class ComposeParameterOrderDetector : ComposableFunctionDetector(), SourceCodeSc
       """
         Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
         Current params are: [$currentOrder] but should be [$properOrder].
-
         See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information.
       """
         .trimIndent()

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewNamingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewNamingDetector.kt
@@ -23,7 +23,6 @@ class ComposePreviewNamingDetector : Detector(), SourceCodeScanner {
     fun createMessage(count: Int, suggestedSuffix: String): String =
       """
         Preview annotations with $count preview annotations should end with the `$suggestedSuffix` suffix.
-
         See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information.
       """
         .trimIndent()

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewNamingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewNamingDetector.kt
@@ -22,10 +22,10 @@ class ComposePreviewNamingDetector : Detector(), SourceCodeScanner {
   companion object {
     fun createMessage(count: Int, suggestedSuffix: String): String =
       """
-            Preview annotations with $count preview annotations should end with the `$suggestedSuffix` suffix.
-            
-            See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information.
-        """
+        Preview annotations with $count preview annotations should end with the `$suggestedSuffix` suffix.
+
+        See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information.
+      """
         .trimIndent()
 
     val ISSUE =

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewNamingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewNamingDetector.kt
@@ -22,8 +22,8 @@ class ComposePreviewNamingDetector : Detector(), SourceCodeScanner {
   companion object {
     fun createMessage(count: Int, suggestedSuffix: String): String =
       """
-            Preview annotations with $count preview annotations should end with the `$suggestedSuffix` suffix.\
-            \
+            Preview annotations with $count preview annotations should end with the `$suggestedSuffix` suffix. \
+             \
             See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information.
         """
         .trimIndent()

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewNamingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewNamingDetector.kt
@@ -22,8 +22,8 @@ class ComposePreviewNamingDetector : Detector(), SourceCodeScanner {
   companion object {
     fun createMessage(count: Int, suggestedSuffix: String): String =
       """
-            Preview annotations with $count preview annotations should end with the `$suggestedSuffix` suffix. \
-             \
+            Preview annotations with $count preview annotations should end with the `$suggestedSuffix` suffix.
+            
             See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information.
         """
         .trimIndent()

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewPublicDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewPublicDetector.kt
@@ -43,10 +43,9 @@ constructor(
           briefDescription = "Preview composables should be private",
           explanation =
             """
-          Composables annotated with `@Preview` that are used only for previewing the UI should not be public.
-
-          See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information.
-        """,
+              Composables annotated with `@Preview` that are used only for previewing the UI should not be public.
+              See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information.
+            """,
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewPublicDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewPublicDetector.kt
@@ -43,8 +43,8 @@ constructor(
           briefDescription = "Preview composables should be private",
           explanation =
             """
-          Composables annotated with `@Preview` that are used only for previewing the UI should not be public. \
-           \
+          Composables annotated with `@Preview` that are used only for previewing the UI should not be public.
+          
           See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information.
         """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewPublicDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewPublicDetector.kt
@@ -43,8 +43,8 @@ constructor(
           briefDescription = "Preview composables should be private",
           explanation =
             """
-          Composables annotated with `@Preview` that are used only for previewing the UI should not be public.\
-          \
+          Composables annotated with `@Preview` that are used only for previewing the UI should not be public. \
+           \
           See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information.
         """
               .trimIndent(),

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewPublicDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposePreviewPublicDetector.kt
@@ -44,10 +44,9 @@ constructor(
           explanation =
             """
           Composables annotated with `@Preview` that are used only for previewing the UI should not be public.
-          
+
           See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information.
-        """
-              .trimIndent(),
+        """,
           category = Category.PRODUCTIVITY,
           priority = Priorities.NORMAL,
           severity = Severity.ERROR,

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeRememberMissingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeRememberMissingDetector.kt
@@ -19,12 +19,13 @@ class ComposeRememberMissingDetector : ComposableFunctionDetector(), SourceCodeS
   companion object {
     private fun errorMessage(name: String): String =
       """
-            Using `$name` in a @Composable function without it being inside of a remember function.
-            If you don't remember the state instance, a new state instance will be created when the function is recomposed.
-            
-            See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information.
-        """
+        Using `$name` in a @Composable function without it being inside of a remember function.
+        If you don't remember the state instance, a new state instance will be created when the function is recomposed.
+
+        See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information.
+      """
         .trimIndent()
+
     private val MethodsThatNeedRemembering = setOf("derivedStateOf", "mutableStateOf")
     val DerivedStateOfNotRemembered = errorMessage("derivedStateOf")
     val MutableStateOfNotRemembered = errorMessage("mutableStateOf")

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeRememberMissingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeRememberMissingDetector.kt
@@ -19,9 +19,9 @@ class ComposeRememberMissingDetector : ComposableFunctionDetector(), SourceCodeS
   companion object {
     private fun errorMessage(name: String): String =
       """
-            Using `$name` in a @Composable function without it being inside of a remember function. \
-            If you don't remember the state instance, a new state instance will be created when the function is recomposed. \
-             \
+            Using `$name` in a @Composable function without it being inside of a remember function.
+            If you don't remember the state instance, a new state instance will be created when the function is recomposed.
+            
             See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information.
         """
         .trimIndent()

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeRememberMissingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeRememberMissingDetector.kt
@@ -19,9 +19,9 @@ class ComposeRememberMissingDetector : ComposableFunctionDetector(), SourceCodeS
   companion object {
     private fun errorMessage(name: String): String =
       """
-            Using `$name` in a @Composable function without it being inside of a remember function.\
-            If you don't remember the state instance, a new state instance will be created when the function is recomposed.\
-            \
+            Using `$name` in a @Composable function without it being inside of a remember function. \
+            If you don't remember the state instance, a new state instance will be created when the function is recomposed. \
+             \
             See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information.
         """
         .trimIndent()

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeRememberMissingDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeRememberMissingDetector.kt
@@ -21,7 +21,6 @@ class ComposeRememberMissingDetector : ComposableFunctionDetector(), SourceCodeS
       """
         Using `$name` in a @Composable function without it being inside of a remember function.
         If you don't remember the state instance, a new state instance will be created when the function is recomposed.
-
         See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information.
       """
         .trimIndent()

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeUnstableCollectionsDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeUnstableCollectionsDetector.kt
@@ -24,9 +24,9 @@ class ComposeUnstableCollectionsDetector : ComposableFunctionDetector(), SourceC
 
     fun createErrorMessage(type: String, rawType: String, variable: String) =
       """
-        The Compose Compiler cannot infer the stability of a parameter if a $type is used in it, even if the item type is stable. \
-        You should use Kotlinx Immutable Collections instead: `$variable: Immutable$type` or create an `@Immutable` wrapper for this class: `@Immutable data class ${variable.capitalized}$rawType(val items: $type)` \
-         \
+        The Compose Compiler cannot infer the stability of a parameter if a $type is used in it, even if the item type is stable.
+        You should use Kotlinx Immutable Collections instead: `$variable: Immutable$type` or create an `@Immutable` wrapper for this class: `@Immutable data class ${variable.capitalized}$rawType(val items: $type)`
+        
         See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information.
       """
         .trimIndent()

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeUnstableCollectionsDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeUnstableCollectionsDetector.kt
@@ -26,7 +26,6 @@ class ComposeUnstableCollectionsDetector : ComposableFunctionDetector(), SourceC
       """
         The Compose Compiler cannot infer the stability of a parameter if a $type is used in it, even if the item type is stable.
         You should use Kotlinx Immutable Collections instead: `$variable: Immutable$type` or create an `@Immutable` wrapper for this class: `@Immutable data class ${variable.capitalized}$rawType(val items: $type)`
-
         See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information.
       """
         .trimIndent()

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeUnstableCollectionsDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeUnstableCollectionsDetector.kt
@@ -24,9 +24,9 @@ class ComposeUnstableCollectionsDetector : ComposableFunctionDetector(), SourceC
 
     fun createErrorMessage(type: String, rawType: String, variable: String) =
       """
-        The Compose Compiler cannot infer the stability of a parameter if a $type is used in it, even if the item type is stable.\
-        You should use Kotlinx Immutable Collections instead: `$variable: Immutable$type` or create an `@Immutable` wrapper for this class: `@Immutable data class ${variable.capitalized}$rawType(val items: $type)`\
-        \
+        The Compose Compiler cannot infer the stability of a parameter if a $type is used in it, even if the item type is stable. \
+        You should use Kotlinx Immutable Collections instead: `$variable: Immutable$type` or create an `@Immutable` wrapper for this class: `@Immutable data class ${variable.capitalized}$rawType(val items: $type)` \
+         \
         See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information.
       """
         .trimIndent()

--- a/slack-lint-checks/src/main/java/slack/lint/compose/ComposeUnstableCollectionsDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/compose/ComposeUnstableCollectionsDetector.kt
@@ -26,7 +26,7 @@ class ComposeUnstableCollectionsDetector : ComposableFunctionDetector(), SourceC
       """
         The Compose Compiler cannot infer the stability of a parameter if a $type is used in it, even if the item type is stable.
         You should use Kotlinx Immutable Collections instead: `$variable: Immutable$type` or create an `@Immutable` wrapper for this class: `@Immutable data class ${variable.capitalized}$rawType(val items: $type)`
-        
+
         See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information.
       """
         .trimIndent()

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeCompositionLocalNamingDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeCompositionLocalNamingDetectorTest.kt
@@ -37,10 +37,14 @@ class ComposeCompositionLocalNamingDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/test.kt:2: Error: CompositionLocals should be named using the Local prefix as an adjective, followed by a descriptive noun.See https://twitter.github.io/compose-rules/rules/#naming-compositionlocals-properly for more information. [ComposeCompositionLocalNaming]
+        src/test.kt:2: Error: CompositionLocals should be named using the Local prefix as an adjective, followed by a descriptive noun.
+
+        See https://twitter.github.io/compose-rules/rules/#naming-compositionlocals-properly for more information. [ComposeCompositionLocalNaming]
                         val AppleLocal = staticCompositionLocalOf<String> { "Apple" }
                             ~~~~~~~~~~
-        src/test.kt:3: Error: CompositionLocals should be named using the Local prefix as an adjective, followed by a descriptive noun.See https://twitter.github.io/compose-rules/rules/#naming-compositionlocals-properly for more information. [ComposeCompositionLocalNaming]
+        src/test.kt:3: Error: CompositionLocals should be named using the Local prefix as an adjective, followed by a descriptive noun.
+
+        See https://twitter.github.io/compose-rules/rules/#naming-compositionlocals-properly for more information. [ComposeCompositionLocalNaming]
                         val Plum: String = staticCompositionLocalOf { "Plum" }
                             ~~~~
         2 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeCompositionLocalNamingDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeCompositionLocalNamingDetectorTest.kt
@@ -38,12 +38,10 @@ class ComposeCompositionLocalNamingDetectorTest : BaseSlackLintTest() {
       .expect(
         """
         src/test.kt:2: Error: CompositionLocals should be named using the Local prefix as an adjective, followed by a descriptive noun.
-
         See https://twitter.github.io/compose-rules/rules/#naming-compositionlocals-properly for more information. [ComposeCompositionLocalNaming]
                         val AppleLocal = staticCompositionLocalOf<String> { "Apple" }
                             ~~~~~~~~~~
         src/test.kt:3: Error: CompositionLocals should be named using the Local prefix as an adjective, followed by a descriptive noun.
-
         See https://twitter.github.io/compose-rules/rules/#naming-compositionlocals-properly for more information. [ComposeCompositionLocalNaming]
                         val Plum: String = staticCompositionLocalOf { "Plum" }
                             ~~~~

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeCompositionLocalUsageDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeCompositionLocalUsageDetectorTest.kt
@@ -40,16 +40,24 @@ class ComposeCompositionLocalUsageDetectorTest : BaseSlackLintTest() {
       .expectErrorCount(4)
       .expect(
         """
-        src/test.kt:2: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
+        src/test.kt:2: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
+
+        See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
                         private val LocalApple = staticCompositionLocalOf<String> { "Apple" }
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        src/test.kt:3: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
+        src/test.kt:3: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
+
+        See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
                         internal val LocalPlum: String = staticCompositionLocalOf { "Plum" }
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        src/test.kt:4: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
+        src/test.kt:4: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
+
+        See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
                         val LocalPrune = compositionLocalOf { "Prune" }
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        src/test.kt:5: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
+        src/test.kt:5: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
+
+        See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
                         private val LocalKiwi: String = compositionLocalOf { "Kiwi" }
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         4 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeCompositionLocalUsageDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeCompositionLocalUsageDetectorTest.kt
@@ -41,22 +41,18 @@ class ComposeCompositionLocalUsageDetectorTest : BaseSlackLintTest() {
       .expect(
         """
         src/test.kt:2: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
-
         See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
                         private val LocalApple = staticCompositionLocalOf<String> { "Apple" }
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         src/test.kt:3: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
-
         See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
                         internal val LocalPlum: String = staticCompositionLocalOf { "Plum" }
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         src/test.kt:4: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
-
         See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
                         val LocalPrune = compositionLocalOf { "Prune" }
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         src/test.kt:5: Error: `CompositionLocal`s are implicit dependencies and creating new ones should be avoided.
-
         See https://twitter.github.io/compose-rules/rules/#compositionlocals for more information. [ComposeCompositionLocalUsage]
                         private val LocalKiwi: String = compositionLocalOf { "Kiwi" }
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeContentEmitterReturningValuesDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeContentEmitterReturningValuesDetectorTest.kt
@@ -90,10 +90,16 @@ class ComposeContentEmitterReturningValuesDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:1: Error: Composable functions should either emit content into the composition or return a value, but not both.If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
+          src/test.kt:1: Error: Composable functions should either emit content into the composition or return a value, but not both.
+          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
+
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^
-          src/test.kt:6: Error: Composable functions should either emit content into the composition or return a value, but not both.If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
+          src/test.kt:6: Error: Composable functions should either emit content into the composition or return a value, but not both.
+          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
+
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^
           2 errors, 0 warnings
@@ -137,10 +143,16 @@ class ComposeContentEmitterReturningValuesDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:5: Error: Composable functions should either emit content into the composition or return a value, but not both.If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
+          src/test.kt:5: Error: Composable functions should either emit content into the composition or return a value, but not both.
+          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
+
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^
-          src/test.kt:18: Error: Composable functions should either emit content into the composition or return a value, but not both.If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
+          src/test.kt:18: Error: Composable functions should either emit content into the composition or return a value, but not both.
+          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
+
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^
           2 errors, 0 warnings
@@ -172,7 +184,10 @@ class ComposeContentEmitterReturningValuesDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:1: Error: Composable functions should either emit content into the composition or return a value, but not both.If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
+          src/test.kt:1: Error: Composable functions should either emit content into the composition or return a value, but not both.
+          If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
+
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^
           1 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeContentEmitterReturningValuesDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeContentEmitterReturningValuesDetectorTest.kt
@@ -92,13 +92,11 @@ class ComposeContentEmitterReturningValuesDetectorTest : BaseSlackLintTest() {
         """
           src/test.kt:1: Error: Composable functions should either emit content into the composition or return a value, but not both.
           If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
-
           See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^
           src/test.kt:6: Error: Composable functions should either emit content into the composition or return a value, but not both.
           If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
-
           See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^
@@ -145,13 +143,11 @@ class ComposeContentEmitterReturningValuesDetectorTest : BaseSlackLintTest() {
         """
           src/test.kt:5: Error: Composable functions should either emit content into the composition or return a value, but not both.
           If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
-
           See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^
           src/test.kt:18: Error: Composable functions should either emit content into the composition or return a value, but not both.
           If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
-
           See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^
@@ -186,7 +182,6 @@ class ComposeContentEmitterReturningValuesDetectorTest : BaseSlackLintTest() {
         """
           src/test.kt:1: Error: Composable functions should either emit content into the composition or return a value, but not both.
           If a composable should offer additional control surfaces to its caller, those control surfaces or callbacks should be provided as parameters to the composable function by the caller.
-
           See https://twitter.github.io/compose-rules/rules/#do-not-emit-content-and-return-a-result for more information. [ComposeContentEmitterReturningValues]
           @Composable
           ^

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeModifierMissingDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeModifierMissingDetectorTest.kt
@@ -56,17 +56,14 @@ class ComposeModifierMissingDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           src/test.kt:2: Error: This @Composable function emits content but doesn't have a modifier parameter.
-
           See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something1() {
               ~~~~~~~~~~
           src/test.kt:7: Error: This @Composable function emits content but doesn't have a modifier parameter.
-
           See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something2() {
               ~~~~~~~~~~
           src/test.kt:12: Error: This @Composable function emits content but doesn't have a modifier parameter.
-
           See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something3(): Unit {
               ~~~~~~~~~~
@@ -103,12 +100,10 @@ class ComposeModifierMissingDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           src/test.kt:2: Error: This @Composable function emits content but doesn't have a modifier parameter.
-
           See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something1() {
               ~~~~~~~~~~
           src/test.kt:7: Error: This @Composable function emits content but doesn't have a modifier parameter.
-
           See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something2(): Unit {
               ~~~~~~~~~~
@@ -288,7 +283,6 @@ class ComposeModifierMissingDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           src/test.kt:2: Error: This @Composable function emits content but doesn't have a modifier parameter.
-
           See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun MyDialog() {
               ~~~~~~~~

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeModifierMissingDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeModifierMissingDetectorTest.kt
@@ -55,13 +55,19 @@ class ComposeModifierMissingDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:2: Error: This @Composable function emits content but doesn't have a modifier parameter.See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
+          src/test.kt:2: Error: This @Composable function emits content but doesn't have a modifier parameter.
+
+          See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something1() {
               ~~~~~~~~~~
-          src/test.kt:7: Error: This @Composable function emits content but doesn't have a modifier parameter.See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
+          src/test.kt:7: Error: This @Composable function emits content but doesn't have a modifier parameter.
+
+          See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something2() {
               ~~~~~~~~~~
-          src/test.kt:12: Error: This @Composable function emits content but doesn't have a modifier parameter.See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
+          src/test.kt:12: Error: This @Composable function emits content but doesn't have a modifier parameter.
+
+          See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something3(): Unit {
               ~~~~~~~~~~
           3 errors, 0 warnings
@@ -96,10 +102,14 @@ class ComposeModifierMissingDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:2: Error: This @Composable function emits content but doesn't have a modifier parameter.See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
+          src/test.kt:2: Error: This @Composable function emits content but doesn't have a modifier parameter.
+
+          See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something1() {
               ~~~~~~~~~~
-          src/test.kt:7: Error: This @Composable function emits content but doesn't have a modifier parameter.See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
+          src/test.kt:7: Error: This @Composable function emits content but doesn't have a modifier parameter.
+
+          See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something2(): Unit {
               ~~~~~~~~~~
           2 errors, 0 warnings
@@ -277,7 +287,9 @@ class ComposeModifierMissingDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:2: Error: This @Composable function emits content but doesn't have a modifier parameter.See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
+          src/test.kt:2: Error: This @Composable function emits content but doesn't have a modifier parameter.
+
+          See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun MyDialog() {
               ~~~~~~~~
           1 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeModifierReusedDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeModifierReusedDetectorTest.kt
@@ -74,79 +74,57 @@ class ComposeModifierReusedDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           src/test.kt:3: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Row(modifier) {
               ^
           src/test.kt:4: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   SomethingElse(modifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~
           src/test.kt:9: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Column(modifier = modifier) {
               ^
           src/test.kt:11: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   SomethingDifferent(modifier = modifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           src/test.kt:16: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Column(modifier = modifier) {
               ^
           src/test.kt:19: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               SomethingElse(modifier = modifier)
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           src/test.kt:20: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               SomethingElse(modifier = modifier.padding12())
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           src/test.kt:25: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   SomethingElse(myMod)
                   ~~~~~~~~~~~~~~~~~~~~
           src/test.kt:26: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   SomethingElse(myMod)
                   ~~~~~~~~~~~~~~~~~~~~
           src/test.kt:31: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Box(
               ^
           src/test.kt:37: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   Box(
                   ^
@@ -191,44 +169,32 @@ class ComposeModifierReusedDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           src/test.kt:3: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Column(modifier = modifier) {
               ^
           src/test.kt:4: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   ChildThatReusesModifier(modifier = modifier.fillMaxWidth())
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           src/test.kt:9: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Column(modifier = modifier) {
               ^
           src/test.kt:11: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   ChildThatReusesModifier(modifier = newModifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           src/test.kt:17: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Column(modifier = modifier) {
               ^
           src/test.kt:18: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   ChildThatReusesModifier(modifier = newModifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -276,51 +242,37 @@ class ComposeModifierReusedDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           src/test.kt:6: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Column(modifier = modifier) {
               ^
           src/test.kt:8: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   ComposableThaReusesModifier(modifier = tweakedModifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           src/test.kt:9: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   ComposableThaReusesModifier(modifier = reassignedModifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           src/test.kt:12: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               InnerComposable(modifier = tweakedModifier)
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           src/test.kt:16: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Column(modifier = modifier) {
               ^
           src/test.kt:20: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   ComposableThaReusesModifier(modifier = tweakedModifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           src/test.kt:21: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
-
           Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
-
           See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   ComposableThaReusesModifier(modifier = reassignedModifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeModifierReusedDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeModifierReusedDetectorTest.kt
@@ -73,37 +73,81 @@ class ComposeModifierReusedDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:3: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:3: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Row(modifier) {
               ^
-          src/test.kt:4: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:4: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   SomethingElse(modifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:9: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:9: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Column(modifier = modifier) {
               ^
-          src/test.kt:11: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:11: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   SomethingDifferent(modifier = modifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:16: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:16: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Column(modifier = modifier) {
               ^
-          src/test.kt:19: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:19: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               SomethingElse(modifier = modifier)
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:20: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:20: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               SomethingElse(modifier = modifier.padding12())
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:25: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:25: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   SomethingElse(myMod)
                   ~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:26: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:26: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   SomethingElse(myMod)
                   ~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:31: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:31: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Box(
               ^
-          src/test.kt:37: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:37: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   Box(
                   ^
           11 errors, 0 warnings
@@ -146,22 +190,46 @@ class ComposeModifierReusedDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:3: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:3: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Column(modifier = modifier) {
               ^
-          src/test.kt:4: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:4: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   ChildThatReusesModifier(modifier = modifier.fillMaxWidth())
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:9: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:9: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Column(modifier = modifier) {
               ^
-          src/test.kt:11: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:11: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   ChildThatReusesModifier(modifier = newModifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:17: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:17: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Column(modifier = modifier) {
               ^
-          src/test.kt:18: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:18: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   ChildThatReusesModifier(modifier = newModifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           6 errors, 0 warnings
@@ -207,25 +275,53 @@ class ComposeModifierReusedDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:6: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:6: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Column(modifier = modifier) {
               ^
-          src/test.kt:8: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:8: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   ComposableThaReusesModifier(modifier = tweakedModifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:9: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:9: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   ComposableThaReusesModifier(modifier = reassignedModifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:12: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:12: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               InnerComposable(modifier = tweakedModifier)
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:16: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:16: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
               Column(modifier = modifier) {
               ^
-          src/test.kt:20: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:20: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   ComposableThaReusesModifier(modifier = tweakedModifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:21: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
+          src/test.kt:21: Error: Modifiers should only be used once and by the root level layout of a Composable. This is true even if appended to or with other modifiers e.g. modifier.fillMaxWidth().
+
+          Use Modifier (with a capital 'M') to construct a new Modifier that you can pass to other composables.
+
+          See https://twitter.github.io/compose-rules/rules/#dont-re-use-modifiers for more information. [ComposeModifierReused]
                   ComposableThaReusesModifier(modifier = reassignedModifier)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           7 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeModifierWithoutDefaultDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeModifierWithoutDefaultDetectorTest.kt
@@ -36,10 +36,14 @@ class ComposeModifierWithoutDefaultDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:2: Error: This @Composable function has a modifier parameter but it doesn't have a default value.See https://twitter.github.io/compose-rules/rules/#modifiers-should-have-default-parameters for more information. [ComposeModifierWithoutDefault]
+          src/test.kt:2: Error: This @Composable function has a modifier parameter but it doesn't have a default value.
+
+          See https://twitter.github.io/compose-rules/rules/#modifiers-should-have-default-parameters for more information. [ComposeModifierWithoutDefault]
           fun Something(modifier: Modifier) { }
                         ~~~~~~~~~~~~~~~~~~
-          src/test.kt:4: Error: This @Composable function has a modifier parameter but it doesn't have a default value.See https://twitter.github.io/compose-rules/rules/#modifiers-should-have-default-parameters for more information. [ComposeModifierWithoutDefault]
+          src/test.kt:4: Error: This @Composable function has a modifier parameter but it doesn't have a default value.
+
+          See https://twitter.github.io/compose-rules/rules/#modifiers-should-have-default-parameters for more information. [ComposeModifierWithoutDefault]
           fun Something(modifier: Modifier = Modifier, modifier2: Modifier) { }
                                                        ~~~~~~~~~~~~~~~~~~~
           2 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeModifierWithoutDefaultDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeModifierWithoutDefaultDetectorTest.kt
@@ -37,12 +37,10 @@ class ComposeModifierWithoutDefaultDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           src/test.kt:2: Error: This @Composable function has a modifier parameter but it doesn't have a default value.
-
           See https://twitter.github.io/compose-rules/rules/#modifiers-should-have-default-parameters for more information. [ComposeModifierWithoutDefault]
           fun Something(modifier: Modifier) { }
                         ~~~~~~~~~~~~~~~~~~
           src/test.kt:4: Error: This @Composable function has a modifier parameter but it doesn't have a default value.
-
           See https://twitter.github.io/compose-rules/rules/#modifiers-should-have-default-parameters for more information. [ComposeModifierWithoutDefault]
           fun Something(modifier: Modifier = Modifier, modifier2: Modifier) { }
                                                        ~~~~~~~~~~~~~~~~~~~

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeMultipleContentEmittersDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeMultipleContentEmittersDetectorTest.kt
@@ -91,12 +91,10 @@ class ComposeMultipleContentEmittersDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.
-
           See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
           src/test.kt:6: Error: Composable functions should only be emitting content into the composition from one source at their top level.
-
           See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
@@ -142,12 +140,10 @@ class ComposeMultipleContentEmittersDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           src/test.kt:5: Error: Composable functions should only be emitting content into the composition from one source at their top level.
-
           See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
           src/test.kt:18: Error: Composable functions should only be emitting content into the composition from one source at their top level.
-
           See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
@@ -181,7 +177,6 @@ class ComposeMultipleContentEmittersDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.
-
           See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeMultipleContentEmittersDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeMultipleContentEmittersDetectorTest.kt
@@ -90,10 +90,14 @@ class ComposeMultipleContentEmittersDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
-          src/test.kt:6: Error: Composable functions should only be emitting content into the composition from one source at their top level.See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:6: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
           2 errors, 0 warnings
@@ -137,10 +141,14 @@ class ComposeMultipleContentEmittersDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:5: Error: Composable functions should only be emitting content into the composition from one source at their top level.See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:5: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
-          src/test.kt:18: Error: Composable functions should only be emitting content into the composition from one source at their top level.See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:18: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
           2 errors, 0 warnings
@@ -172,7 +180,9 @@ class ComposeMultipleContentEmittersDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
+          src/test.kt:1: Error: Composable functions should only be emitting content into the composition from one source at their top level.
+
+          See https://twitter.github.io/compose-rules/rules/#do-not-emit-multiple-pieces-of-content for more information. [ComposeMultipleContentEmitters]
           @Composable
           ^
           1 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeMutableParametersDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeMutableParametersDetectorTest.kt
@@ -45,16 +45,28 @@ class ComposeMutableParametersDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:2: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
+          src/test.kt:2: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
+          Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
+
+          See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something(a: MutableState<String>) {}
               ~~~~~~~~~
-          src/test.kt:4: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
+          src/test.kt:4: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
+          Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
+
+          See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something(a: ArrayList<String>) {}
               ~~~~~~~~~
-          src/test.kt:6: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
+          src/test.kt:6: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
+          Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
+
+          See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something(a: HashSet<String>) {}
               ~~~~~~~~~
-          src/test.kt:8: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
+          src/test.kt:8: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
+          Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
+
+          See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something(a: MutableMap<String, String>) {}
               ~~~~~~~~~
           4 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeMutableParametersDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeMutableParametersDetectorTest.kt
@@ -47,25 +47,21 @@ class ComposeMutableParametersDetectorTest : BaseSlackLintTest() {
         """
           src/test.kt:2: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
           Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
-
           See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something(a: MutableState<String>) {}
               ~~~~~~~~~
           src/test.kt:4: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
           Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
-
           See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something(a: ArrayList<String>) {}
               ~~~~~~~~~
           src/test.kt:6: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
           Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
-
           See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something(a: HashSet<String>) {}
               ~~~~~~~~~
           src/test.kt:8: Error: Using mutable objects as state in Compose will cause your users to see incorrect or stale data in your app.
           Mutable objects that are not observable, such as ArrayList<T> or a mutable data class, cannot be observed by Compose to trigger recomposition when they change.
-
           See https://twitter.github.io/compose-rules/rules/#when-should-i-expose-modifier-parameters for more information. [ComposeModifierMissing]
           fun Something(a: MutableMap<String, String>) {}
               ~~~~~~~~~

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeNamingDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeNamingDetectorTest.kt
@@ -14,7 +14,7 @@ class ComposeNamingDetectorTest : BaseSlackLintTest() {
 
   override fun getDetector(): Detector = ComposeNamingDetector()
   override fun getIssues(): List<Issue> = ComposeNamingDetector.ISSUES.toList()
-  //
+
   // This mode is irrelevant to our test and totally untestable with stringy outputs
   override val skipTestModes: Array<TestMode> = arrayOf(TestMode.SUPPRESSIBLE, TestMode.TYPE_ALIAS)
 
@@ -124,10 +124,10 @@ class ComposeNamingDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:2: Error: Composable functions that return Unit should start with an uppercase letter.They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information. [ComposeNaming]
+          src/test.kt:2: Error: Composable functions that return Unit should start with an uppercase letter. They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.  See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information. [ComposeNaming]
           fun myComposable() { }
               ~~~~~~~~~~~~
-          src/test.kt:5: Error: Composable functions that return Unit should start with an uppercase letter.They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information. [ComposeNaming]
+          src/test.kt:5: Error: Composable functions that return Unit should start with an uppercase letter. They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.  See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information. [ComposeNaming]
           fun myComposable(): Unit { }
               ~~~~~~~~~~~~
           2 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeNamingDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeNamingDetectorTest.kt
@@ -98,7 +98,6 @@ class ComposeNamingDetectorTest : BaseSlackLintTest() {
         """
           src/test.kt:2: Error: Composable functions that return a value should start with a lowercase letter.
           While useful and accepted outside of @Composable functions, this factory function convention has drawbacks that set inappropriate expectations for callers when used with @Composable functions.
-
           See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information. [ComposeNaming]
           fun MyComposable(): Something { }
               ~~~~~~~~~~~~
@@ -129,13 +128,11 @@ class ComposeNamingDetectorTest : BaseSlackLintTest() {
         """
           src/test.kt:2: Error: Composable functions that return Unit should start with an uppercase letter.
           They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.
-
           See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information. [ComposeNaming]
           fun myComposable() { }
               ~~~~~~~~~~~~
           src/test.kt:5: Error: Composable functions that return Unit should start with an uppercase letter.
           They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.
-
           See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information. [ComposeNaming]
           fun myComposable(): Unit { }
               ~~~~~~~~~~~~

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeNamingDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeNamingDetectorTest.kt
@@ -96,7 +96,10 @@ class ComposeNamingDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:2: Error: Composable functions that return a value should start with a lowercase letter.While useful and accepted outside of @Composable functions, this factory function convention has drawbacks that set inappropriate expectations for callers when used with @Composable functions.See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information. [ComposeNaming]
+          src/test.kt:2: Error: Composable functions that return a value should start with a lowercase letter.
+          While useful and accepted outside of @Composable functions, this factory function convention has drawbacks that set inappropriate expectations for callers when used with @Composable functions.
+
+          See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information. [ComposeNaming]
           fun MyComposable(): Something { }
               ~~~~~~~~~~~~
           1 errors, 0 warnings
@@ -124,10 +127,16 @@ class ComposeNamingDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:2: Error: Composable functions that return Unit should start with an uppercase letter. They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.  See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information. [ComposeNaming]
+          src/test.kt:2: Error: Composable functions that return Unit should start with an uppercase letter.
+          They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.
+
+          See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information. [ComposeNaming]
           fun myComposable() { }
               ~~~~~~~~~~~~
-          src/test.kt:5: Error: Composable functions that return Unit should start with an uppercase letter. They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.  See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information. [ComposeNaming]
+          src/test.kt:5: Error: Composable functions that return Unit should start with an uppercase letter.
+          They are considered declarative entities that can be either present or absent in a composition and therefore follow the naming rules for classes.
+
+          See https://twitter.github.io/compose-rules/rules/#naming-composable-functions-properly for more information. [ComposeNaming]
           fun myComposable(): Unit { }
               ~~~~~~~~~~~~
           2 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeParameterOrderDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeParameterOrderDetectorTest.kt
@@ -64,19 +64,34 @@ class ComposeParameterOrderDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:1: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.Current params are: [modifier: Modifier = Modifier, other: String, other2: String] but should be [other: String, other2: String, modifier: Modifier = Modifier].See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
+          src/test.kt:1: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+          Current params are: [modifier: Modifier = Modifier, other: String, other2: String] but should be [other: String, other2: String, modifier: Modifier = Modifier].
+
+          See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
           @Composable
           ^
-          src/test.kt:4: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.Current params are: [text: String = "deffo", modifier: Modifier = Modifier] but should be [modifier: Modifier = Modifier, text: String = "deffo"].See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
+          src/test.kt:4: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+          Current params are: [text: String = "deffo", modifier: Modifier = Modifier] but should be [modifier: Modifier = Modifier, text: String = "deffo"].
+
+          See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
           @Composable
           ^
-          src/test.kt:7: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.Current params are: [modifier: Modifier = Modifier, text: String = "123", modifier2: Modifier = Modifier] but should be [modifier: Modifier = Modifier, modifier2: Modifier = Modifier, text: String = "123"].See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
+          src/test.kt:7: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+          Current params are: [modifier: Modifier = Modifier, text: String = "123", modifier2: Modifier = Modifier] but should be [modifier: Modifier = Modifier, modifier2: Modifier = Modifier, text: String = "123"].
+
+          See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
           @Composable
           ^
-          src/test.kt:10: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.Current params are: [text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit] but should be [modifier: Modifier = Modifier, text: String = "123", lambda: () -> Unit].See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
+          src/test.kt:10: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+          Current params are: [text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit] but should be [modifier: Modifier = Modifier, text: String = "123", lambda: () -> Unit].
+
+          See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
           @Composable
           ^
-          src/test.kt:13: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.Current params are: [text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit] but should be [text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit].See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
+          src/test.kt:13: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
+          Current params are: [text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit] but should be [text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit].
+
+          See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
           @Composable
           ^
           5 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeParameterOrderDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeParameterOrderDetectorTest.kt
@@ -66,31 +66,26 @@ class ComposeParameterOrderDetectorTest : BaseSlackLintTest() {
         """
           src/test.kt:1: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
           Current params are: [modifier: Modifier = Modifier, other: String, other2: String] but should be [other: String, other2: String, modifier: Modifier = Modifier].
-
           See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
           @Composable
           ^
           src/test.kt:4: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
           Current params are: [text: String = "deffo", modifier: Modifier = Modifier] but should be [modifier: Modifier = Modifier, text: String = "deffo"].
-
           See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
           @Composable
           ^
           src/test.kt:7: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
           Current params are: [modifier: Modifier = Modifier, text: String = "123", modifier2: Modifier = Modifier] but should be [modifier: Modifier = Modifier, modifier2: Modifier = Modifier, text: String = "123"].
-
           See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
           @Composable
           ^
           src/test.kt:10: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
           Current params are: [text: String = "123", modifier: Modifier = Modifier, lambda: () -> Unit] but should be [modifier: Modifier = Modifier, text: String = "123", lambda: () -> Unit].
-
           See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
           @Composable
           ^
           src/test.kt:13: Error: Parameters in a composable function should be ordered following this pattern: params without defaults, modifiers, params with defaults and optionally, a trailing function that might not have a default param.
           Current params are: [text1: String, m2: Modifier = Modifier, modifier: Modifier = Modifier, trailing: () -> Unit] but should be [text1: String, modifier: Modifier = Modifier, m2: Modifier = Modifier, trailing: () -> Unit].
-
           See https://twitter.github.io/compose-rules/rules/#ordering-composable-parameters-properly for more information. [ComposeModifierWithoutDefault]
           @Composable
           ^

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposePreviewNamingDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposePreviewNamingDetectorTest.kt
@@ -70,13 +70,19 @@ class ComposePreviewNamingDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/Banana.kt:1: Error: Preview annotations with 1 preview annotations should end with the Preview suffix.See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
+          src/Banana.kt:1: Error: Preview annotations with 1 preview annotations should end with the Preview suffix.
+
+          See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
           @Preview
           ^
-          src/Banana.kt:3: Error: Preview annotations with 1 preview annotations should end with the Preview suffix.See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
+          src/Banana.kt:3: Error: Preview annotations with 1 preview annotations should end with the Preview suffix.
+
+          See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
           @Preview
           ^
-          src/Banana.kt:5: Error: Preview annotations with 1 preview annotations should end with the Preview suffix.See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
+          src/Banana.kt:5: Error: Preview annotations with 1 preview annotations should end with the Preview suffix.
+
+          See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
           @BananaPreview
           ^
           3 errors, 0 warnings
@@ -104,10 +110,14 @@ class ComposePreviewNamingDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/BananaPreview.kt:1: Error: Preview annotations with 2 preview annotations should end with the Previews suffix.See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
+          src/BananaPreview.kt:1: Error: Preview annotations with 2 preview annotations should end with the Previews suffix.
+
+          See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
           @Preview
           ^
-          src/BananaPreview.kt:4: Error: Preview annotations with 2 preview annotations should end with the Previews suffix.See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
+          src/BananaPreview.kt:4: Error: Preview annotations with 2 preview annotations should end with the Previews suffix.
+
+          See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
           @BananaPreview
           ^
           2 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposePreviewNamingDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposePreviewNamingDetectorTest.kt
@@ -71,17 +71,14 @@ class ComposePreviewNamingDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           src/Banana.kt:1: Error: Preview annotations with 1 preview annotations should end with the Preview suffix.
-
           See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
           @Preview
           ^
           src/Banana.kt:3: Error: Preview annotations with 1 preview annotations should end with the Preview suffix.
-
           See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
           @Preview
           ^
           src/Banana.kt:5: Error: Preview annotations with 1 preview annotations should end with the Preview suffix.
-
           See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
           @BananaPreview
           ^
@@ -111,12 +108,10 @@ class ComposePreviewNamingDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           src/BananaPreview.kt:1: Error: Preview annotations with 2 preview annotations should end with the Previews suffix.
-
           See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
           @Preview
           ^
           src/BananaPreview.kt:4: Error: Preview annotations with 2 preview annotations should end with the Previews suffix.
-
           See https://twitter.github.io/compose-rules/rules/#naming-multipreview-annotations-properly for more information. [ComposePreviewNaming]
           @BananaPreview
           ^

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposePreviewPublicDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposePreviewPublicDetectorTest.kt
@@ -66,12 +66,10 @@ class ComposePreviewPublicDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           src/test.kt:1: Error: Composables annotated with @Preview that are used only for previewing the UI should not be public.
-
           See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information. [ComposePreviewPublic]
           @Preview
           ^
           src/test.kt:4: Error: Composables annotated with @Preview that are used only for previewing the UI should not be public.
-
           See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information. [ComposePreviewPublic]
           @CombinedPreviews
           ^
@@ -117,12 +115,10 @@ class ComposePreviewPublicDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           src/test.kt:1: Error: Composables annotated with @Preview that are used only for previewing the UI should not be public.
-
           See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information. [ComposePreviewPublic]
           @Preview
           ^
           src/test.kt:5: Error: Composables annotated with @Preview that are used only for previewing the UI should not be public.
-
           See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information. [ComposePreviewPublic]
           @CombinedPreviews
           ^

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposePreviewPublicDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposePreviewPublicDetectorTest.kt
@@ -65,10 +65,14 @@ class ComposePreviewPublicDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:1: Error: Composables annotated with @Preview that are used only for previewing the UI should not be public.See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information. [ComposePreviewPublic]
+          src/test.kt:1: Error: Composables annotated with @Preview that are used only for previewing the UI should not be public.
+
+          See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information. [ComposePreviewPublic]
           @Preview
           ^
-          src/test.kt:4: Error: Composables annotated with @Preview that are used only for previewing the UI should not be public.See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information. [ComposePreviewPublic]
+          src/test.kt:4: Error: Composables annotated with @Preview that are used only for previewing the UI should not be public.
+
+          See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information. [ComposePreviewPublic]
           @CombinedPreviews
           ^
           2 errors, 0 warnings
@@ -112,10 +116,14 @@ class ComposePreviewPublicDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:1: Error: Composables annotated with @Preview that are used only for previewing the UI should not be public.See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information. [ComposePreviewPublic]
+          src/test.kt:1: Error: Composables annotated with @Preview that are used only for previewing the UI should not be public.
+
+          See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information. [ComposePreviewPublic]
           @Preview
           ^
-          src/test.kt:5: Error: Composables annotated with @Preview that are used only for previewing the UI should not be public.See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information. [ComposePreviewPublic]
+          src/test.kt:5: Error: Composables annotated with @Preview that are used only for previewing the UI should not be public.
+
+          See https://twitter.github.io/compose-rules/rules/#preview-composables-should-not-be-public for more information. [ComposePreviewPublic]
           @CombinedPreviews
           ^
           2 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeRememberMissingDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeRememberMissingDetectorTest.kt
@@ -50,13 +50,11 @@ class ComposeRememberMissingDetectorTest : BaseSlackLintTest() {
         """
           src/test.kt:3: Error: Using mutableStateOf in a @Composable function without it being inside of a remember function.
           If you don't remember the state instance, a new state instance will be created when the function is recomposed.
-
           See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information. [ComposeRememberMissing]
               val something = mutableStateOf("X")
                               ~~~~~~~~~~~~~~~~~~~
           src/test.kt:6: Error: Using mutableStateOf in a @Composable function without it being inside of a remember function.
           If you don't remember the state instance, a new state instance will be created when the function is recomposed.
-
           See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information. [ComposeRememberMissing]
           fun MyComposable(something: State<String> = mutableStateOf("X")) {
                                                       ~~~~~~~~~~~~~~~~~~~
@@ -133,13 +131,11 @@ class ComposeRememberMissingDetectorTest : BaseSlackLintTest() {
         """
           src/test.kt:3: Error: Using derivedStateOf in a @Composable function without it being inside of a remember function.
           If you don't remember the state instance, a new state instance will be created when the function is recomposed.
-
           See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information. [ComposeRememberMissing]
               val something = derivedStateOf { "X" }
                               ~~~~~~~~~~~~~~~~~~~~~~
           src/test.kt:6: Error: Using derivedStateOf in a @Composable function without it being inside of a remember function.
           If you don't remember the state instance, a new state instance will be created when the function is recomposed.
-
           See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information. [ComposeRememberMissing]
           fun MyComposable(something: State<String> = derivedStateOf { "X" }) {
                                                       ~~~~~~~~~~~~~~~~~~~~~~

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeRememberMissingDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeRememberMissingDetectorTest.kt
@@ -48,10 +48,16 @@ class ComposeRememberMissingDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:3: Error: Using mutableStateOf in a @Composable function without it being inside of a remember function.If you don't remember the state instance, a new state instance will be created when the function is recomposed.See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information. [ComposeRememberMissing]
+          src/test.kt:3: Error: Using mutableStateOf in a @Composable function without it being inside of a remember function.
+          If you don't remember the state instance, a new state instance will be created when the function is recomposed.
+
+          See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information. [ComposeRememberMissing]
               val something = mutableStateOf("X")
                               ~~~~~~~~~~~~~~~~~~~
-          src/test.kt:6: Error: Using mutableStateOf in a @Composable function without it being inside of a remember function.If you don't remember the state instance, a new state instance will be created when the function is recomposed.See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information. [ComposeRememberMissing]
+          src/test.kt:6: Error: Using mutableStateOf in a @Composable function without it being inside of a remember function.
+          If you don't remember the state instance, a new state instance will be created when the function is recomposed.
+
+          See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information. [ComposeRememberMissing]
           fun MyComposable(something: State<String> = mutableStateOf("X")) {
                                                       ~~~~~~~~~~~~~~~~~~~
           2 errors, 0 warnings
@@ -125,10 +131,16 @@ class ComposeRememberMissingDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:3: Error: Using derivedStateOf in a @Composable function without it being inside of a remember function.If you don't remember the state instance, a new state instance will be created when the function is recomposed.See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information. [ComposeRememberMissing]
+          src/test.kt:3: Error: Using derivedStateOf in a @Composable function without it being inside of a remember function.
+          If you don't remember the state instance, a new state instance will be created when the function is recomposed.
+
+          See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information. [ComposeRememberMissing]
               val something = derivedStateOf { "X" }
                               ~~~~~~~~~~~~~~~~~~~~~~
-          src/test.kt:6: Error: Using derivedStateOf in a @Composable function without it being inside of a remember function.If you don't remember the state instance, a new state instance will be created when the function is recomposed.See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information. [ComposeRememberMissing]
+          src/test.kt:6: Error: Using derivedStateOf in a @Composable function without it being inside of a remember function.
+          If you don't remember the state instance, a new state instance will be created when the function is recomposed.
+
+          See https://twitter.github.io/compose-rules/rules/#state-should-be-remembered-in-composables for more information. [ComposeRememberMissing]
           fun MyComposable(something: State<String> = derivedStateOf { "X" }) {
                                                       ~~~~~~~~~~~~~~~~~~~~~~
           2 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeUnstableCollectionsDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeUnstableCollectionsDetectorTest.kt
@@ -40,16 +40,28 @@ class ComposeUnstableCollectionsDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test.kt:2: Error: The Compose Compiler cannot infer the stability of a parameter if a Collection<String> is used in it, even if the item type is stable.You should use Kotlinx Immutable Collections instead: a: ImmutableCollection<String> or create an @Immutable wrapper for this class: @Immutable data class ACollection(val items: Collection<String>)See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information. [ComposeModifierWithoutDefault]
+          src/test.kt:2: Error: The Compose Compiler cannot infer the stability of a parameter if a Collection<String> is used in it, even if the item type is stable.
+          You should use Kotlinx Immutable Collections instead: a: ImmutableCollection<String> or create an @Immutable wrapper for this class: @Immutable data class ACollection(val items: Collection<String>)
+
+          See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information. [ComposeModifierWithoutDefault]
           fun Something(a: Collection<String>) {}
                            ~~~~~~~~~~~~~~~~~~
-          src/test.kt:4: Error: The Compose Compiler cannot infer the stability of a parameter if a List<String> is used in it, even if the item type is stable.You should use Kotlinx Immutable Collections instead: a: ImmutableList<String> or create an @Immutable wrapper for this class: @Immutable data class AList(val items: List<String>)See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information. [ComposeModifierWithoutDefault]
+          src/test.kt:4: Error: The Compose Compiler cannot infer the stability of a parameter if a List<String> is used in it, even if the item type is stable.
+          You should use Kotlinx Immutable Collections instead: a: ImmutableList<String> or create an @Immutable wrapper for this class: @Immutable data class AList(val items: List<String>)
+
+          See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information. [ComposeModifierWithoutDefault]
           fun Something(a: List<String>) {}
                            ~~~~~~~~~~~~
-          src/test.kt:6: Error: The Compose Compiler cannot infer the stability of a parameter if a Set<String> is used in it, even if the item type is stable.You should use Kotlinx Immutable Collections instead: a: ImmutableSet<String> or create an @Immutable wrapper for this class: @Immutable data class ASet(val items: Set<String>)See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information. [ComposeModifierWithoutDefault]
+          src/test.kt:6: Error: The Compose Compiler cannot infer the stability of a parameter if a Set<String> is used in it, even if the item type is stable.
+          You should use Kotlinx Immutable Collections instead: a: ImmutableSet<String> or create an @Immutable wrapper for this class: @Immutable data class ASet(val items: Set<String>)
+
+          See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information. [ComposeModifierWithoutDefault]
           fun Something(a: Set<String>) {}
                            ~~~~~~~~~~~
-          src/test.kt:8: Error: The Compose Compiler cannot infer the stability of a parameter if a Map<String, Int> is used in it, even if the item type is stable.You should use Kotlinx Immutable Collections instead: a: ImmutableMap<String, Int> or create an @Immutable wrapper for this class: @Immutable data class AMap(val items: Map<String, Int>)See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information. [ComposeModifierWithoutDefault]
+          src/test.kt:8: Error: The Compose Compiler cannot infer the stability of a parameter if a Map<String, Int> is used in it, even if the item type is stable.
+          You should use Kotlinx Immutable Collections instead: a: ImmutableMap<String, Int> or create an @Immutable wrapper for this class: @Immutable data class AMap(val items: Map<String, Int>)
+
+          See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information. [ComposeModifierWithoutDefault]
           fun Something(a: Map<String, Int>) {}
                            ~~~~~~~~~~~~~~~~
           4 errors, 0 warnings

--- a/slack-lint-checks/src/test/java/slack/lint/compose/ComposeUnstableCollectionsDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/compose/ComposeUnstableCollectionsDetectorTest.kt
@@ -42,25 +42,21 @@ class ComposeUnstableCollectionsDetectorTest : BaseSlackLintTest() {
         """
           src/test.kt:2: Error: The Compose Compiler cannot infer the stability of a parameter if a Collection<String> is used in it, even if the item type is stable.
           You should use Kotlinx Immutable Collections instead: a: ImmutableCollection<String> or create an @Immutable wrapper for this class: @Immutable data class ACollection(val items: Collection<String>)
-
           See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information. [ComposeModifierWithoutDefault]
           fun Something(a: Collection<String>) {}
                            ~~~~~~~~~~~~~~~~~~
           src/test.kt:4: Error: The Compose Compiler cannot infer the stability of a parameter if a List<String> is used in it, even if the item type is stable.
           You should use Kotlinx Immutable Collections instead: a: ImmutableList<String> or create an @Immutable wrapper for this class: @Immutable data class AList(val items: List<String>)
-
           See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information. [ComposeModifierWithoutDefault]
           fun Something(a: List<String>) {}
                            ~~~~~~~~~~~~
           src/test.kt:6: Error: The Compose Compiler cannot infer the stability of a parameter if a Set<String> is used in it, even if the item type is stable.
           You should use Kotlinx Immutable Collections instead: a: ImmutableSet<String> or create an @Immutable wrapper for this class: @Immutable data class ASet(val items: Set<String>)
-
           See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information. [ComposeModifierWithoutDefault]
           fun Something(a: Set<String>) {}
                            ~~~~~~~~~~~
           src/test.kt:8: Error: The Compose Compiler cannot infer the stability of a parameter if a Map<String, Int> is used in it, even if the item type is stable.
           You should use Kotlinx Immutable Collections instead: a: ImmutableMap<String, Int> or create an @Immutable wrapper for this class: @Immutable data class AMap(val items: Map<String, Int>)
-
           See https://twitter.github.io/compose-rules/rules/#avoid-using-unstable-collections for more information. [ComposeModifierWithoutDefault]
           fun Something(a: Map<String, Int>) {}
                            ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Figured out a few things

- I had the trailing `\` characters backward. That's only if you want to continue on a newline in source but not actually in the real message. So I've removed them here as we _do_ want the newlines where they are.
- Figured out the trimIndent() stuff. It's not necessary when passing a string into the explanation field of an `Issue` creation, but _is_ still necessary for messages passed into a `context.report(...)` call.
- Removed extra newlines in explanations (see comments below w/ screenshots for why).