### PR TITLE
Implement ParcelizeFunctionPropertyDetectorTest

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/SlackIssueRegistry.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/SlackIssueRegistry.kt
@@ -14,6 +14,7 @@ import slack.lint.mocking.AutoValueMockDetector
 import slack.lint.mocking.DataClassMockDetector
 import slack.lint.mocking.DoNotMockMockDetector
 import slack.lint.mocking.ErrorProneDoNotMockDetector
+import slack.lint.parcel.ParcelizeFunctionPropertyDetector
 import slack.lint.resources.FullyQualifiedResourceDetector
 import slack.lint.resources.MissingResourceImportAliasDetector
 import slack.lint.resources.WrongResourceImportAliasDetector
@@ -63,5 +64,6 @@ class SlackIssueRegistry : IssueRegistry() {
       MissingResourceImportAliasDetector.ISSUE,
       WrongResourceImportAliasDetector.ISSUE,
       DenyListedApiDetector.ISSUE,
+      ParcelizeFunctionPropertyDetector.ISSUE,
     )
 }

--- a/slack-lint-checks/src/main/java/slack/lint/parcel/ParcelizeFunctionPropertyDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/parcel/ParcelizeFunctionPropertyDetector.kt
@@ -1,0 +1,81 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.parcel
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import com.android.tools.lint.detector.api.getUMethod
+import com.android.tools.lint.detector.api.isJava
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiType
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import slack.lint.util.sourceImplementation
+
+/** @see ISSUE */
+class ParcelizeFunctionPropertyDetector : Detector(), SourceCodeScanner {
+
+  override fun getApplicableUastTypes(): List<Class<out UElement>> {
+    return listOf(UClass::class.java)
+  }
+
+  override fun createUastHandler(context: JavaContext): UElementHandler? {
+    // Parcelize can only be used in Kotlin files, so this check only checks in Kotlin files
+    if (isJava(context.psiFile)) return null
+    return object : UElementHandler() {
+      override fun visitClass(node: UClass) {
+        if (!node.hasAnnotation(PARCELIZE)) return
+
+        // Primary constructor is required, but Parcelize's inspections will catch this
+        val primaryConstructor =
+          node.constructors
+            .asSequence()
+            .mapNotNull { it.getUMethod() }
+            .firstOrNull { it.sourcePsi is KtPrimaryConstructor }
+            ?: return
+
+        // Now check properties
+        for (parameter in primaryConstructor.uastParameters) {
+          if (parameter.type.isFunctionType && !parameter.hasAnnotation(IGNORED_ON_PARCEL)) {
+            context.report(
+              ISSUE,
+              context.getLocation(parameter.typeReference),
+              ISSUE.getExplanation(TextFormat.TEXT),
+            )
+          }
+        }
+      }
+
+      private val PsiType.isFunctionType: Boolean
+        get() =
+          this is PsiClassType &&
+            resolve()?.qualifiedName?.startsWith("kotlin.jvm.functions.Function") == true
+    }
+  }
+
+  companion object {
+    private const val PARCELIZE_PACKAGE = "kotlinx.parcelize"
+    private const val PARCELIZE = "$PARCELIZE_PACKAGE.Parcelize"
+    private const val IGNORED_ON_PARCEL = "$PARCELIZE_PACKAGE.IgnoredOnParcel"
+
+    internal val ISSUE: Issue =
+      Issue.create(
+        "ParcelizeFunctionProperty",
+        "Function type properties should not be used in Parcelize classes",
+        "While technically (and surprisingly) supported by Parcelize, function types " +
+          "should not be used in Parcelize classes. There are only limited conditions where it " +
+          "will work and it's usually a sign that you're modeling your data wrong.",
+        Category.CORRECTNESS,
+        9,
+        Severity.ERROR,
+        sourceImplementation<ParcelizeFunctionPropertyDetector>()
+      )
+  }
+}

--- a/slack-lint-checks/src/test/java/slack/lint/parcel/ParcelizeFunctionPropertyDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/parcel/ParcelizeFunctionPropertyDetectorTest.kt
@@ -1,0 +1,97 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.parcel
+
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+
+class ParcelizeFunctionPropertyDetectorTest : BaseSlackLintTest() {
+
+  companion object {
+    private val PARCELIZE_STUBS =
+      kotlin(
+          "test/kotlinx/parcelize/Parcelize.kt",
+          """
+        package kotlinx.parcelize
+
+        annotation class Parcelize
+        annotation class IgnoredOnParcel
+      """
+        )
+        .indented()
+    private val PARCELABLE_STUBS =
+      kotlin(
+          "test/android/os/Parcelable.kt",
+          """
+        package android.os
+
+        interface Parcelable
+      """
+        )
+        .indented()
+  }
+
+  override fun getDetector() = ParcelizeFunctionPropertyDetector()
+  override fun getIssues() = listOf(ParcelizeFunctionPropertyDetector.ISSUE)
+
+  @Test
+  fun simple() {
+    lint()
+      .files(
+        PARCELIZE_STUBS,
+        PARCELABLE_STUBS,
+        kotlin(
+            """
+          package test.pkg
+
+          import android.os.Parcelable
+          import kotlinx.parcelize.Parcelize
+          import kotlinx.parcelize.IgnoredOnParcel
+
+          typealias FunctionType = () -> String
+
+          @Parcelize
+          class Example1(
+            val foo: String,
+            val functionType1: () -> String,
+            val functionType2: (String) -> String,
+            val functionType3: String.() -> String,
+            val functionType4: () -> Unit,
+            val functionType5: suspend () -> Unit,
+            val aliasedFunction: FunctionType,
+            val functionClass: FunctionClass,
+            @IgnoredOnParcel
+            val ignoredFunction: () -> Unit = {}, // This is allowed
+          ) : Parcelable
+          """
+          )
+          .indented()
+      )
+      .allowCompilationErrors(false)
+      .run()
+      .expect(
+        """
+        src/test/pkg/Example1.kt:12: Error: While technically (and surprisingly) supported by Parcelize, function types should not be used in Parcelize classes. There are only limited conditions where it will work and it's usually a sign that you're modeling your data wrong. [ParcelizeFunctionProperty]
+          val functionType1: () -> String,
+                             ~~~~~~~~~~~~
+        src/test/pkg/Example1.kt:13: Error: While technically (and surprisingly) supported by Parcelize, function types should not be used in Parcelize classes. There are only limited conditions where it will work and it's usually a sign that you're modeling your data wrong. [ParcelizeFunctionProperty]
+          val functionType2: (String) -> String,
+                             ~~~~~~~~~~~~~~~~~~
+        src/test/pkg/Example1.kt:14: Error: While technically (and surprisingly) supported by Parcelize, function types should not be used in Parcelize classes. There are only limited conditions where it will work and it's usually a sign that you're modeling your data wrong. [ParcelizeFunctionProperty]
+          val functionType3: String.() -> String,
+                             ~~~~~~~~~~~~~~~~~~~
+        src/test/pkg/Example1.kt:15: Error: While technically (and surprisingly) supported by Parcelize, function types should not be used in Parcelize classes. There are only limited conditions where it will work and it's usually a sign that you're modeling your data wrong. [ParcelizeFunctionProperty]
+          val functionType4: () -> Unit,
+                             ~~~~~~~~~~
+        src/test/pkg/Example1.kt:16: Error: While technically (and surprisingly) supported by Parcelize, function types should not be used in Parcelize classes. There are only limited conditions where it will work and it's usually a sign that you're modeling your data wrong. [ParcelizeFunctionProperty]
+          val functionType5: suspend () -> Unit,
+                             ~~~~~~~~~~~~~~~~~~
+        src/test/pkg/Example1.kt:17: Error: While technically (and surprisingly) supported by Parcelize, function types should not be used in Parcelize classes. There are only limited conditions where it will work and it's usually a sign that you're modeling your data wrong. [ParcelizeFunctionProperty]
+          val aliasedFunction: FunctionType,
+                               ~~~~~~~~~~~~
+        6 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+}


### PR DESCRIPTION
While technically allowed by Parcelize in certain conditions, function types shouldn't be used in parcelized classes because they quickly explode when they become capturing lambdas.

Two things worth calling out
- I couldn't actually coerce the type to a `KtLambdaExpression` at any point, despite what the IJ PSI viewer suggested. So instead I use a bit of a wonky package name check. Suggestions welcome.
- This doesn't currently check for supertypes, i.e. `class Example : () -> Unit`. At that point I assume parcelize will kick in on a declared type and request that you implement parcelable for it.