### PR TITLE
Use kotlinx-metadata for more accurate Kotlin checks

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,12 +13,14 @@ dokka = { id = "org.jetbrains.dokka", version = "1.8.10" }
 lint = { id = "com.android.lint", version = "8.0.2" }
 ksp = { id = "com.google.devtools.ksp", version = "1.8.21-1.0.11" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.25.2" }
+mavenShadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
 spotless = { id = "com.diffplug.spotless", version = "6.19.0" }
 
 [libraries]
 autoService-annotations = "com.google.auto.service:auto-service-annotations:1.1.0"
 autoService-ksp = "dev.zacsweers.autoservice:auto-service-ksp:1.0.0"
 junit = "junit:junit:4.13.2"
+kotlin-metadata = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version = "0.6.0" }
 ktfmt = { module = "com.facebook:ktfmt", version.ref = "ktfmt" }
 eithernet = "com.slack.eithernet:eithernet:1.4.0"
 retrofit = "com.squareup.retrofit2:retrofit:2.9.0"

--- a/slack-lint-checks/build.gradle.kts
+++ b/slack-lint-checks/build.gradle.kts
@@ -1,5 +1,6 @@
 // Copyright (C) 2021 Slack Technologies, LLC
 // SPDX-License-Identifier: Apache-2.0
+import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -9,6 +10,7 @@ plugins {
   alias(libs.plugins.lint)
   alias(libs.plugins.ksp)
   alias(libs.plugins.mavenPublish)
+  alias(libs.plugins.mavenShadow)
 }
 
 lint {
@@ -20,10 +22,15 @@ lint {
   baseline = file("lint-baseline.xml")
 }
 
+val shade: Configuration = configurations.maybeCreate("compileShaded")
+
+configurations.getByName("compileOnly").extendsFrom(shade)
+
 dependencies {
   compileOnly(libs.bundles.lintApi)
   ksp(libs.autoService.ksp)
   implementation(libs.autoService.annotations)
+  shade(libs.kotlin.metadata) { exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib") }
   testImplementation(libs.bundles.lintTest)
   testImplementation(libs.junit)
 
@@ -39,4 +46,19 @@ tasks.withType<KotlinCompile>().configureEach {
     apiVersion.set(KotlinVersion.KOTLIN_1_8)
     languageVersion.set(KotlinVersion.KOTLIN_1_8)
   }
+}
+
+val shadowJar =
+  tasks.shadowJar.apply {
+    configure {
+      archiveClassifier.set("")
+      configurations = listOf(shade)
+      relocate("kotlinx.metadata", "slack.lint.shaded.kotlinx.metadata")
+      transformers.add(ServiceFileTransformer())
+    }
+  }
+
+artifacts {
+  runtimeOnly(shadowJar)
+  archives(shadowJar)
 }

--- a/slack-lint-checks/build.gradle.kts
+++ b/slack-lint-checks/build.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
   ksp(libs.autoService.ksp)
   implementation(libs.autoService.annotations)
   shade(libs.kotlin.metadata) { exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib") }
+
+  // Dupe the dep because the shaded version is compileOnly in the eyes of the gradle configurations
+  testImplementation(libs.kotlin.metadata)
   testImplementation(libs.bundles.lintTest)
   testImplementation(libs.junit)
 

--- a/slack-lint-checks/src/main/java/slack/lint/mocking/AbstractMockDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/mocking/AbstractMockDetector.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package slack.lint.mocking
 
+import com.android.tools.lint.client.api.JavaEvaluator
 import com.android.tools.lint.client.api.UElementHandler
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.JavaContext
@@ -19,6 +20,7 @@ import org.jetbrains.uast.UField
 import org.jetbrains.uast.UReferenceExpression
 import org.jetbrains.uast.UVariable
 import org.jetbrains.uast.getParentOfType
+import slack.lint.util.SlackJavaEvaluator
 
 /**
  * A base detector class for detecting different kinds of mocking behavior. Subclasses can indicate
@@ -39,7 +41,11 @@ abstract class AbstractMockDetector : Detector(), SourceCodeScanner {
   /** Set of annotation FQCNs that should not be mocked */
   open val annotations: Set<String> = emptySet()
 
-  open fun checkType(context: JavaContext, mockedType: PsiClass): Reason? {
+  open fun checkType(
+    context: JavaContext,
+    evaluator: JavaEvaluator,
+    mockedType: PsiClass
+  ): Reason? {
     return null
   }
 
@@ -53,6 +59,7 @@ abstract class AbstractMockDetector : Detector(), SourceCodeScanner {
   override fun getApplicableUastTypes() = listOf(UCallExpression::class.java, UField::class.java)
 
   override fun createUastHandler(context: JavaContext): UElementHandler {
+    val slackEvaluator = SlackJavaEvaluator(context.file.name, context.evaluator)
     return object : UElementHandler() {
 
       // Checks for mock()/spy() calls
@@ -64,22 +71,22 @@ abstract class AbstractMockDetector : Detector(), SourceCodeScanner {
           var argumentType: PsiClass? = null
           if (node.typeArgumentCount == 1) {
             // We can read the type here for the fun <reified T> mock() helpers
-            argumentType = context.evaluator.getTypeClass(node.typeArguments[0])
+            argumentType = slackEvaluator.getTypeClass(node.typeArguments[0])
           } else if (resolvedClass in MOCK_CLASSES && node.valueArgumentCount != 0) {
             when (val firstArg = node.valueArguments[0]) {
               is UClassLiteralExpression -> {
                 // It's Foo.class, we can just use it directly
-                argumentType = context.evaluator.getTypeClass(firstArg.type)
+                argumentType = slackEvaluator.getTypeClass(firstArg.type)
               }
               is UReferenceExpression -> {
                 val type = firstArg.getExpressionType()
                 if (node.methodName == "spy") {
                   // spy takes an instance, so take the type at face value
-                  argumentType = context.evaluator.getTypeClass(type)
+                  argumentType = slackEvaluator.getTypeClass(type)
                 } else if (type is PsiClassType && type.parameterCount == 1) {
                   // If it's a Class and not a "spy" method, assume it's the mock type
                   val classGeneric = type.parameters[0]
-                  argumentType = context.evaluator.getTypeClass(classGeneric)
+                  argumentType = slackEvaluator.getTypeClass(classGeneric)
                 }
               }
             }
@@ -88,7 +95,7 @@ abstract class AbstractMockDetector : Detector(), SourceCodeScanner {
             // Covers cases like `val dynamicMock: TestClass = mock()`
             val variable = node.getParentOfType<UVariable>() ?: return
             nodeToReport = variable
-            argumentType = context.evaluator.getTypeClass(variable.type)
+            argumentType = slackEvaluator.getTypeClass(variable.type)
           }
 
           argumentType?.let { checkMock(nodeToReport, argumentType) }
@@ -100,12 +107,12 @@ abstract class AbstractMockDetector : Detector(), SourceCodeScanner {
         if (isKotlin(node)) {
           val sourcePsi = node.sourcePsi ?: return
           if (sourcePsi is KtProperty && isMockAnnotated(node)) {
-            val type = context.evaluator.getTypeClass(node.type) ?: return
+            val type = slackEvaluator.getTypeClass(node.type) ?: return
             checkMock(node, type)
             return
           }
         } else if (isJava(node) && isMockAnnotated(node)) {
-          val type = context.evaluator.getTypeClass(node.type) ?: return
+          val type = slackEvaluator.getTypeClass(node.type) ?: return
           checkMock(node, type)
           return
         }
@@ -116,7 +123,7 @@ abstract class AbstractMockDetector : Detector(), SourceCodeScanner {
       }
 
       private fun checkMock(node: UElement, type: PsiClass) {
-        val reason = checkType(context, type)
+        val reason = checkType(context, slackEvaluator, type)
         if (reason != null) {
           report(context, type, node, reason)
           return
@@ -138,10 +145,7 @@ abstract class AbstractMockDetector : Detector(), SourceCodeScanner {
   /**
    * @property type a [PsiClass] object representing the class that should not be mocked.
    * @property reason The reason this class should not be mocked, which may be as simple as "it is
-   *
-   * ```
-   *                  annotated to forbid mocking" but may also provide a suggested workaround.
-   * ```
+   *   annotated to forbid mocking" but may also provide a suggested workaround.
    */
   data class Reason(val type: PsiClass, val reason: String)
 }

--- a/slack-lint-checks/src/main/java/slack/lint/mocking/DataClassMockDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/mocking/DataClassMockDetector.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package slack.lint.mocking
 
+import com.android.tools.lint.client.api.JavaEvaluator
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.JavaContext
@@ -30,8 +31,12 @@ class DataClassMockDetector : AbstractMockDetector() {
 
   override val annotations: Set<String> = emptySet()
 
-  override fun checkType(context: JavaContext, mockedType: PsiClass): Reason? {
-    return if (context.evaluator.isData(mockedType)) {
+  override fun checkType(
+    context: JavaContext,
+    evaluator: JavaEvaluator,
+    mockedType: PsiClass
+  ): Reason? {
+    return if (evaluator.isData(mockedType)) {
       Reason(
         mockedType,
         "data classes represent pure value classes, so mocking them should not be necessary"

--- a/slack-lint-checks/src/main/java/slack/lint/mocking/DoNotMockMockDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/mocking/DoNotMockMockDetector.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package slack.lint.mocking
 
+import com.android.tools.lint.client.api.JavaEvaluator
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.JavaContext
@@ -34,7 +35,11 @@ class DoNotMockMockDetector : AbstractMockDetector() {
     private const val FQCN_EP_DNM = "com.google.errorprone.annotations.DoNotMock"
   }
 
-  override fun checkType(context: JavaContext, mockedType: PsiClass): Reason? {
+  override fun checkType(
+    context: JavaContext,
+    evaluator: JavaEvaluator,
+    mockedType: PsiClass
+  ): Reason? {
     val uMockedType = mockedType.toUElementOfType<UClass>() ?: return null
     val doNotMockAnnotation =
       uMockedType.findAnnotation(FQCN_SLACK_DNM)

--- a/slack-lint-checks/src/main/java/slack/lint/util/LintUtils.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/util/LintUtils.kt
@@ -42,12 +42,9 @@ import org.jetbrains.uast.tryResolve
 /**
  * @param qualifiedName the qualified name of the desired interface type
  * @param nameFilter an optional name filter, used to check when to stop searching up the type
- *
- * ```
- *                   hierarchy. This is useful if you want to only check direct implementers in
- *                   certain packages. Called with a fully qualified class name; return false if
- *                   you want to stop searching up the type tree, true to continue.
- * ```
+ *   hierarchy. This is useful if you want to only check direct implementers in certain packages.
+ *   Called with a fully qualified class name; return false if you want to stop searching up the
+ *   type tree, true to continue.
  */
 internal fun PsiClass.implements(
   qualifiedName: String,
@@ -309,4 +306,27 @@ internal fun StringOption.loadAsSet(
     .map(String::trim)
     .filter(String::isNotBlank)
     .toSet()
+}
+
+internal inline fun <T, reified R> Array<out T>.mapArray(transform: (T) -> R): Array<R> =
+  Array(this.size) { i -> transform(this[i]) }
+
+internal inline fun <T> measureTimeMillisWithResult(block: () -> T): Pair<Long, T> {
+  val start = System.currentTimeMillis()
+  val result = block()
+  return Pair(System.currentTimeMillis() - start, result)
+}
+
+private val logVerbosely by lazy {
+  System.getProperty("slack.lint.logVerbosely", "false").toBoolean()
+}
+
+/**
+ * Logs to std if [logVerbosely] is enabled. Useful for debugging and should not generally be
+ * enabled.
+ */
+internal fun slackLintLog(message: String) {
+  if (logVerbosely) {
+    println("SlackLint: $message")
+  }
 }

--- a/slack-lint-checks/src/main/java/slack/lint/util/SlackJavaEvaluator.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/util/SlackJavaEvaluator.kt
@@ -1,0 +1,229 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.util
+
+import com.android.tools.lint.client.api.JavaEvaluator
+import com.android.tools.lint.model.LintModelDependencies
+import com.intellij.lang.jvm.JvmClassKind
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiArrayInitializerMemberValue
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiCompiledElement
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiLiteralExpression
+import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.PsiPackage
+import com.intellij.psi.PsiType
+import java.util.Optional
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.jvm.optionals.getOrNull
+import kotlinx.metadata.Flag
+import kotlinx.metadata.KmClass
+import kotlinx.metadata.jvm.KotlinClassMetadata
+import kotlinx.metadata.jvm.Metadata as MetadataWithNullableArgs
+import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.uast.UAnnotated
+import org.jetbrains.uast.UAnnotation
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.findContaining
+
+/**
+ * A delegating [JavaEvaluator] that implements more comprehensive checks for Kotlin classes via
+ * metadata annotations.
+ *
+ * This is important because, when `checkDependencies` is set to false, Lint detectors cannot see
+ * Kotlin language features in externally-compiled elements. This means that constructs like `data
+ * classes` or similar are not visible. Using kotlinx-metadata, we can parse the [Metadata]
+ * annotations on the containing classes and read these language features from them.
+ */
+@Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+class SlackJavaEvaluator(private val file: String, private val delegate: JavaEvaluator) :
+  JavaEvaluator() {
+
+  private companion object {
+    // Not an exhaustive list, but at least the ones we look at currently
+    private val KOTLIN_CLASS_MODIFIER_TOKENS =
+      mapOf(
+        KtTokens.DATA_KEYWORD to TokenData(Flag.Class.IS_DATA),
+        KtTokens.SEALED_KEYWORD to
+          TokenData(
+            Flag.IS_SEALED,
+            applicableClassKinds = setOf(JvmClassKind.CLASS, JvmClassKind.INTERFACE)
+          ),
+        KtTokens.OBJECT_KEYWORD to TokenData(Flag.Class.IS_OBJECT),
+        KtTokens.COMPANION_KEYWORD to TokenData(Flag.Class.IS_COMPANION_OBJECT),
+        KtTokens.VALUE_KEYWORD to TokenData(Flag.Class.IS_VALUE),
+      )
+  }
+
+  private data class TokenData(
+    val flag: Flag,
+    val applicableClassKinds: Set<JvmClassKind> = setOf(JvmClassKind.CLASS)
+  )
+
+  /** Flag to disable as needed. */
+  private val checkMetadata = System.getProperty("slack.lint.checkMetadata", "true").toBoolean()
+  private val cachedClasses = ConcurrentHashMap<String, Optional<KmClass>>()
+
+  // region Delegating functions
+  override val dependencies: LintModelDependencies?
+    get() = delegate.dependencies
+
+  override fun extendsClass(cls: PsiClass?, className: String, strict: Boolean): Boolean =
+    delegate.extendsClass(cls, className, strict)
+
+  override fun findAnnotation(
+    listOwner: PsiModifierListOwner?,
+    vararg annotationNames: String
+  ): PsiAnnotation? = delegate.findAnnotation(listOwner, *annotationNames)
+
+  override fun findAnnotationInHierarchy(
+    listOwner: PsiModifierListOwner,
+    vararg annotationNames: String
+  ): PsiAnnotation? = delegate.findAnnotationInHierarchy(listOwner, *annotationNames)
+
+  override fun findClass(qualifiedName: String): PsiClass? = delegate.findClass(qualifiedName)
+
+  override fun findJarPath(element: PsiElement): String? = delegate.findJarPath(element)
+
+  override fun findJarPath(element: UElement): String? = delegate.findJarPath(element)
+
+  override fun getAllAnnotations(
+    owner: PsiModifierListOwner,
+    inHierarchy: Boolean
+  ): Array<PsiAnnotation> = delegate.getAllAnnotations(owner, inHierarchy)
+
+  override fun getAllAnnotations(owner: UAnnotated, inHierarchy: Boolean): List<UAnnotation> =
+    delegate.getAllAnnotations(owner, inHierarchy)
+
+  override fun getAnnotation(
+    listOwner: PsiModifierListOwner?,
+    vararg annotationNames: String
+  ): UAnnotation? = delegate.getAnnotation(listOwner, *annotationNames)
+
+  override fun getAnnotationInHierarchy(
+    listOwner: PsiModifierListOwner,
+    vararg annotationNames: String
+  ): UAnnotation? = delegate.getAnnotationInHierarchy(listOwner, *annotationNames)
+
+  override fun getAnnotations(
+    owner: PsiModifierListOwner?,
+    inHierarchy: Boolean,
+    parent: UElement?
+  ): List<UAnnotation> = delegate.getAnnotations(owner, inHierarchy, parent)
+
+  override fun getClassType(psiClass: PsiClass?): PsiClassType? = delegate.getClassType(psiClass)
+
+  override fun getPackage(node: PsiElement): PsiPackage? = delegate.getPackage(node)
+
+  override fun getPackage(node: UElement): PsiPackage? = delegate.getPackage(node)
+
+  override fun getTypeClass(psiType: PsiType?): PsiClass? = delegate.getTypeClass(psiType)
+
+  override fun implementsInterface(cls: PsiClass, interfaceName: String, strict: Boolean): Boolean =
+    delegate.implementsInterface(cls, interfaceName, strict)
+  // endregion
+
+  override fun hasModifier(owner: PsiModifierListOwner?, keyword: KtModifierKeywordToken): Boolean {
+    val superValue = super.hasModifier(owner, keyword)
+    // If it's not a compiled element or not a PsiClass, trust the super value and move on
+    if (!checkMetadata || owner !is PsiCompiledElement || owner !is PsiClass) {
+      return superValue
+    }
+
+    // We're working with an externally compiled element and it's a PsiClass, so we can do more
+    // thorough checks here.
+    KOTLIN_CLASS_MODIFIER_TOKENS[keyword]?.let { (flag, applicableClassKinds) ->
+      owner.findContaining(UClass::class.java)?.let { cls ->
+        // Only parse if the target class kind is applicable to the token we're checking. For
+        // example - when checking `data` tokens, they're not applicable to interfaces or enums.
+        if (cls.classKind in applicableClassKinds) {
+          cls.getOrParseMetadata()?.let { kmClass ->
+            return flag(kmClass.flags)
+          }
+        }
+      }
+    }
+
+    return superValue
+  }
+
+  private fun UAnnotated.getOrParseMetadata(): KmClass? {
+    val cls =
+      when (this) {
+        is UClass -> this
+        else -> return null // Only classes are supported right now
+      }
+    return cachedClasses
+      // Don't use getOrPut. Kotlin's extension may still invoke the body and we don't want that
+      .computeIfAbsent(qualifiedName!!) { key ->
+        val annotation =
+          cls.findAnnotation("kotlin.Metadata") ?: return@computeIfAbsent Optional.empty()
+        val (durationMillis, metadata) =
+          measureTimeMillisWithResult { annotation.parseMetadata(key) }
+        slackLintLog("Took ${durationMillis}ms to parse metadata for $key.")
+        Optional.ofNullable(metadata)
+      }
+      .getOrNull()
+  }
+
+  private fun UAnnotation.parseMetadata(classNameHint: String): KmClass? {
+    val metadataAnnotation =
+      MetadataWithNullableArgs(
+        kind = findAttributeValue("k")?.parseIntMember(),
+        metadataVersion = findAttributeValue("mv")?.parseIntArray(),
+        data1 = findAttributeValue("d1")?.parseStringArray(),
+        data2 = findAttributeValue("d2")?.parseStringArray(),
+        extraString = findAttributeValue("xs")?.parseStringMember(),
+        packageName = findAttributeValue("pn")?.parseStringMember(),
+        extraInt = findAttributeValue("xi")?.parseIntMember(),
+      )
+    val metadata = KotlinClassMetadata.read(metadataAnnotation)
+    return when (metadata) {
+      is KotlinClassMetadata.Class -> metadata.toKmClass()
+      is KotlinClassMetadata.FileFacade -> null
+      is KotlinClassMetadata.MultiFileClassFacade -> null
+      is KotlinClassMetadata.MultiFileClassPart -> null
+      is KotlinClassMetadata.SyntheticClass -> null
+      is KotlinClassMetadata.Unknown -> null
+      null -> {
+        slackLintLog("Could not load metadata for $classNameHint from file $file")
+        null
+      }
+    }.also {
+      if (it == null) {
+        slackLintLog(
+          "Could not load KmClass for $classNameHint from file $file. Metadata was $metadata"
+        )
+      } else {
+        slackLintLog("Loaded KmClass for $classNameHint from file $file")
+      }
+    }
+  }
+
+  private val PsiLiteralExpression.intValue: Int
+    get() = stringValue.toInt()
+
+  private val PsiLiteralExpression.stringValue: String
+    get() = value.toString()
+
+  private fun UExpression.parseIntMember() = (sourcePsi as PsiLiteralExpression).intValue
+
+  private fun UExpression.parseStringMember() = (sourcePsi as PsiLiteralExpression).stringValue
+
+  private fun UExpression.parseStringArray() =
+    (sourcePsi as PsiArrayInitializerMemberValue).initializers.mapArray { value ->
+      (value as PsiLiteralExpression).stringValue
+    }
+
+  private fun UExpression.parseIntArray(): IntArray {
+    val initializers = (sourcePsi as PsiArrayInitializerMemberValue).initializers
+    return IntArray(initializers.size) { index ->
+      (initializers[index] as PsiLiteralExpression).intValue
+    }
+  }
+}


### PR DESCRIPTION
Resolves #53

This implements a new decorating `SlackJavaEvaluator` that leverages Kotlin `Metadata` to understand kotlin langauge features of externally compiled elements. This is important as these elements otherwise appear to lint as just plain Java classes. I've done a bunch of testing with this in the Slack Android repo, and the timings are always ~1ms, rarely exceeding it to 2ms. Just in case though, I've gated this behavior with a system property.

Currently this is only used in the DoNotMock checkers, but is usable in other future checkers.