### PR TITLE
Improve location reporting + fix type resolution in mock detector

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/util/LintUtils.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/util/LintUtils.kt
@@ -319,6 +319,9 @@ internal inline fun <T> measureTimeMillisWithResult(block: () -> T): Pair<Long, 
 private val logVerbosely by lazy {
   System.getProperty("slack.lint.logVerbosely", "false").toBoolean()
 }
+private val logErrorsVerbosely by lazy {
+  System.getProperty("slack.lint.logErrorsVerbosely", "true").toBoolean()
+}
 
 /**
  * Logs to std if [logVerbosely] is enabled. Useful for debugging and should not generally be
@@ -327,5 +330,15 @@ private val logVerbosely by lazy {
 internal fun slackLintLog(message: String) {
   if (logVerbosely) {
     println("SlackLint: $message")
+  }
+}
+
+/**
+ * Logs to std if [logErrorsVerbosely] is enabled. Important for errors that you don't necessarily
+ * want to fail the build
+ */
+internal fun slackLintErrorLog(message: String) {
+  if (logErrorsVerbosely) {
+    System.err.println("SlackLint: $message")
   }
 }

--- a/slack-lint-checks/src/main/java/slack/lint/util/MetadataJavaEvaluator.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/util/MetadataJavaEvaluator.kt
@@ -185,9 +185,15 @@ class MetadataJavaEvaluator(private val file: String, private val delegate: Java
         is UClass -> this
         else -> return null // Only classes are supported right now
       }
+    val fqcn =
+      qualifiedName
+        ?: run {
+          slackLintErrorLog("Qualified name is null for $cls in file $file")
+          return null
+        }
     return cachedClasses
       // Don't use getOrPut. Kotlin's extension may still invoke the body and we don't want that
-      .computeIfAbsent(qualifiedName!!) { key ->
+      .computeIfAbsent(fqcn) { key ->
         val annotation =
           cls.findAnnotation("kotlin.Metadata") ?: return@computeIfAbsent Optional.empty()
         val (durationMillis, metadata) =

--- a/slack-lint-checks/src/test/java/slack/lint/mocking/DataClassMockDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/mocking/DataClassMockDetectorTest.kt
@@ -83,7 +83,7 @@ class DataClassMockDetectorTest : BaseSlackLintTest() {
                                 ^
           test/test/slack/test/TestClass.kt:21: Error: data classes represent pure value classes, so mocking them should not be necessary [DoNotMockDataClass]
               val assigned: TestClass = mock()
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                        ~~~~~~
           8 errors, 0 warnings
         """
           .trimIndent()

--- a/slack-lint-checks/src/test/java/slack/lint/mocking/ObjectClassMockDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/mocking/ObjectClassMockDetectorTest.kt
@@ -82,7 +82,7 @@ class ObjectClassMockDetectorTest : BaseSlackLintTest() {
                                 ^
           test/test/slack/test/TestClass.kt:21: Error: object classes are singletons, so mocking them should not be necessary [DoNotMockObjectClass]
               val assigned: TestClass = mock()
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                        ~~~~~~
           8 errors, 0 warnings
         """
           .trimIndent()

--- a/slack-lint-checks/src/test/java/slack/lint/mocking/RecordClassMockDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/mocking/RecordClassMockDetectorTest.kt
@@ -127,7 +127,7 @@ class RecordClassMockDetectorTest : BaseSlackLintTest() {
                                           ^
           test/test/slack/test/TestClass.kt:21: Error: record classes represent pure value classes, so mocking them should not be necessary [DoNotMockRecordClass]
                         val assigned: TestClass = mock()
-                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                                  ~~~~~~
           8 errors, 0 warnings
         """
           .trimIndent()

--- a/slack-lint-checks/src/test/java/slack/lint/mocking/SealedClassMockDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/mocking/SealedClassMockDetectorTest.kt
@@ -121,7 +121,7 @@ class SealedClassMockDetectorTest : BaseSlackLintTest() {
                                           ^
           test/test/slack/test/TestClass.kt:21: Error: sealed classes have a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
                         val assigned: TestClass = mock()
-                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                                  ~~~~~~
           8 errors, 0 warnings
         """
           .trimIndent()


### PR DESCRIPTION
Resolves #74. Also found along the way that we were incorrectly linting the entire variable or field when one of its value arguments were improperly mocked.

This also makes an opportunistic optimization to make the call expression check return early if it's not a method call, as we're not interested in the other ones.