### PR TITLE
Update java sealed test checks

### DIFF
--- a/slack-lint-checks/src/test/java/slack/lint/mocking/SealedClassMockDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/mocking/SealedClassMockDetectorTest.kt
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package slack.lint.mocking
 
+import com.android.tools.lint.checks.infrastructure.TestMode
+import com.intellij.pom.java.LanguageLevel
 import org.junit.Test
 import slack.lint.BaseSlackLintTest
 
@@ -31,14 +33,16 @@ class SealedClassMockDetectorTest : BaseSlackLintTest() {
   private val testClasses =
     arrayOf(
       testClass,
-      // TODO test once lint supports java sealed
-      //  https://issuetracker.google.com/issues/283693337
-      //      javaTestClass,
+      javaTestClass,
     )
 
   override fun getDetector() = MockDetector()
 
   override fun getIssues() = MockDetector.ISSUES.toList()
+
+  override val skipTestModes: Array<TestMode>
+    // I don't understand the point of this mode
+    get() = arrayOf(TestMode.SUPPRESSIBLE)
 
   @Test
   fun kotlinTests() {
@@ -70,28 +74,28 @@ class SealedClassMockDetectorTest : BaseSlackLintTest() {
               val fake = TestClass("this is fine")
             }
 
-            // TODO test once lint supports java sealed
-//            @Mock lateinit var fieldMock2: TestJavaClass
-//            @Spy lateinit var fieldSpy2: TestJavaClass
-//            fun example2() {
-//              val localMock1 = org.mockito.Mockito.mock(TestJavaClass::class.java)
-//              val localSpy1 = org.mockito.Mockito.spy(localMock1)
-//              val localMock2 = mock<TestJavaClass>()
-//              val classRef = TestJavaClass::class.java
-//              val localMock3 = org.mockito.Mockito.mock(classRef)
-//
-//              val dynamicMock = mock<TestJavaClass> {
-//
-//              }
-//              val assigned: TestJavaClass = mock()
-//              val fake = TestJavaClass("this is fine")
-//            }
+            @Mock lateinit var fieldMock2: TestJavaClass
+            @Spy lateinit var fieldSpy2: TestJavaClass
+            fun example2() {
+              val localMock1 = org.mockito.Mockito.mock(TestJavaClass::class.java)
+              val localSpy1 = org.mockito.Mockito.spy(localMock1)
+              val localMock2 = mock<TestJavaClass>()
+              val classRef = TestJavaClass::class.java
+              val localMock3 = org.mockito.Mockito.mock(classRef)
+
+              val dynamicMock = mock<TestJavaClass> {
+
+              }
+              val assigned: TestJavaClass = mock()
+              val fake = TestJavaClass("this is fine")
+            }
           }
         """
         )
         .indented()
 
     lint()
+      .javaLanguageLevel(LanguageLevel.JDK_17)
       .files(*mockFileStubs(), *testClasses, source)
       // https://issuetracker.google.com/issues/283693338
       .allowCompilationErrors()
@@ -99,30 +103,54 @@ class SealedClassMockDetectorTest : BaseSlackLintTest() {
       .expect(
         """
           test/test/slack/test/TestClass.kt:8: Error: 'slack.test.TestClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
-                      @Mock lateinit var fieldMock: TestClass
-                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            @Mock lateinit var fieldMock: TestClass
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           test/test/slack/test/TestClass.kt:9: Error: 'slack.test.TestClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
-                      @Spy lateinit var fieldSpy: TestClass
-                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            @Spy lateinit var fieldSpy: TestClass
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           test/test/slack/test/TestClass.kt:12: Error: 'slack.test.TestClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
-                        val localMock1 = org.mockito.Mockito.mock(TestClass::class.java)
-                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              val localMock1 = org.mockito.Mockito.mock(TestClass::class.java)
+                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           test/test/slack/test/TestClass.kt:13: Error: 'slack.test.TestClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
-                        val localSpy1 = org.mockito.Mockito.spy(localMock1)
-                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              val localSpy1 = org.mockito.Mockito.spy(localMock1)
+                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           test/test/slack/test/TestClass.kt:14: Error: 'slack.test.TestClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
-                        val localMock2 = mock<TestClass>()
-                                         ~~~~~~~~~~~~~~~~~
+              val localMock2 = mock<TestClass>()
+                               ~~~~~~~~~~~~~~~~~
           test/test/slack/test/TestClass.kt:16: Error: 'slack.test.TestClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
-                        val localMock3 = org.mockito.Mockito.mock(classRef)
-                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              val localMock3 = org.mockito.Mockito.mock(classRef)
+                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           test/test/slack/test/TestClass.kt:18: Error: 'slack.test.TestClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
-                        val dynamicMock = mock<TestClass> {
-                                          ^
+              val dynamicMock = mock<TestClass> {
+                                ^
           test/test/slack/test/TestClass.kt:21: Error: 'slack.test.TestClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
-                        val assigned: TestClass = mock()
-                                                  ~~~~~~
-          8 errors, 0 warnings
+              val assigned: TestClass = mock()
+                                        ~~~~~~
+          test/test/slack/test/TestClass.kt:25: Error: 'slack.test.TestJavaClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
+            @Mock lateinit var fieldMock2: TestJavaClass
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          test/test/slack/test/TestClass.kt:26: Error: 'slack.test.TestJavaClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
+            @Spy lateinit var fieldSpy2: TestJavaClass
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          test/test/slack/test/TestClass.kt:28: Error: 'slack.test.TestJavaClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
+              val localMock1 = org.mockito.Mockito.mock(TestJavaClass::class.java)
+                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          test/test/slack/test/TestClass.kt:29: Error: 'slack.test.TestJavaClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
+              val localSpy1 = org.mockito.Mockito.spy(localMock1)
+                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          test/test/slack/test/TestClass.kt:30: Error: 'slack.test.TestJavaClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
+              val localMock2 = mock<TestJavaClass>()
+                               ~~~~~~~~~~~~~~~~~~~~~
+          test/test/slack/test/TestClass.kt:32: Error: 'slack.test.TestJavaClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
+              val localMock3 = org.mockito.Mockito.mock(classRef)
+                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          test/test/slack/test/TestClass.kt:34: Error: 'slack.test.TestJavaClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
+              val dynamicMock = mock<TestJavaClass> {
+                                ^
+          test/test/slack/test/TestClass.kt:37: Error: 'slack.test.TestJavaClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
+              val assigned: TestJavaClass = mock()
+                                            ~~~~~~
+          16 errors, 0 warnings
         """
           .trimIndent()
       )
@@ -153,42 +181,57 @@ class SealedClassMockDetectorTest : BaseSlackLintTest() {
               TestClass fake = new TestClass("this is fine");
             }
 
-            // TODO test once lint supports java sealed
             @Mock TestJavaClass fieldMock2;
             @Spy TestJavaClass fieldSpy2;
-//            public void example2() {
-//              TestClass localMock = mock(TestJavaClass.class);
-//              TestJavaClass localSpy = spy(localMock);
-//              Class<TestJavaClass> classRef = TestJavaClass.class;
-//              TestJavaClass localMock2 = mock(classRef);
-//              TestJavaClass fake = new TestJavaClass("this is fine");
-//            }
+            public void example2() {
+              TestClass localMock = mock(TestJavaClass.class);
+              TestJavaClass localSpy = spy(localMock);
+              Class<TestJavaClass> classRef = TestJavaClass.class;
+              TestJavaClass localMock2 = mock(classRef);
+              TestJavaClass fake = new TestJavaClass("this is fine");
+            }
           }
         """
         )
         .indented()
 
     lint()
+      .javaLanguageLevel(LanguageLevel.JDK_17)
       .files(*mockFileStubs(), *testClasses, source)
       .run()
       .expect(
         """
           test/test/slack/test/TestClass.java:9: Error: 'slack.test.TestClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
-                      @Mock TestClass fieldMock;
-                      ~~~~~~~~~~~~~~~~~~~~~~~~~~
+            @Mock TestClass fieldMock;
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~
           test/test/slack/test/TestClass.java:10: Error: 'slack.test.TestClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
-                      @Spy TestClass fieldSpy;
-                      ~~~~~~~~~~~~~~~~~~~~~~~~
+            @Spy TestClass fieldSpy;
+            ~~~~~~~~~~~~~~~~~~~~~~~~
           test/test/slack/test/TestClass.java:13: Error: 'slack.test.TestClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
-                        TestClass localMock = mock(TestClass.class);
-                                              ~~~~~~~~~~~~~~~~~~~~~
+              TestClass localMock = mock(TestClass.class);
+                                    ~~~~~~~~~~~~~~~~~~~~~
           test/test/slack/test/TestClass.java:14: Error: 'slack.test.TestClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
-                        TestClass localSpy = spy(localMock);
-                                             ~~~~~~~~~~~~~~
+              TestClass localSpy = spy(localMock);
+                                   ~~~~~~~~~~~~~~
           test/test/slack/test/TestClass.java:16: Error: 'slack.test.TestClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
-                        TestClass localMock2 = mock(classRef);
-                                               ~~~~~~~~~~~~~~
-          5 errors, 0 warnings
+              TestClass localMock2 = mock(classRef);
+                                     ~~~~~~~~~~~~~~
+          test/test/slack/test/TestClass.java:20: Error: 'slack.test.TestJavaClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
+            @Mock TestJavaClass fieldMock2;
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          test/test/slack/test/TestClass.java:21: Error: 'slack.test.TestJavaClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
+            @Spy TestJavaClass fieldSpy2;
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          test/test/slack/test/TestClass.java:23: Error: 'slack.test.TestJavaClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
+              TestClass localMock = mock(TestJavaClass.class);
+                                    ~~~~~~~~~~~~~~~~~~~~~~~~~
+          test/test/slack/test/TestClass.java:24: Error: 'slack.test.TestClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
+              TestJavaClass localSpy = spy(localMock);
+                                       ~~~~~~~~~~~~~~
+          test/test/slack/test/TestClass.java:26: Error: 'slack.test.TestJavaClass' is a sealed type and has a restricted type hierarchy, use a subtype instead. [DoNotMockSealedClass]
+              TestJavaClass localMock2 = mock(classRef);
+                                         ~~~~~~~~~~~~~~
+          10 errors, 0 warnings
         """
           .trimIndent()
       )


### PR DESCRIPTION
New lint API unlocked this after https://issuetracker.google.com/issues/283693337 was fixed
