### PR TITLE
Add runCatching to the denylist

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/denylistedapis/DenyListedApiDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/denylistedapis/DenyListedApiDetector.kt
@@ -246,6 +246,14 @@ internal class DenyListedApiDetector : Detector(), SourceCodeScanner, XmlScanner
           ),
         arguments = listOf("*"),
       ),
+      DenyListedEntry(
+        className = "kotlin.ResultKt",
+        functionName = "runCatching",
+        errorMessage =
+          "runCatching has hidden issues when used with coroutines as it catches and doesn't rethrow CancellationException. " +
+            "This can interfere with coroutines cancellation handling! " +
+            "Prefer catching specific exceptions based on the current case.",
+      ),
     )
 
   override fun getApplicableUastTypes() = config.applicableTypes()

--- a/slack-lint-checks/src/test/java/slack/lint/denylistedapis/DenyListedApiDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/denylistedapis/DenyListedApiDetectorTest.kt
@@ -579,6 +579,33 @@ class DenyListedApiDetectorTest : BaseSlackLintTest() {
       .expectClean()
   }
 
+  @Test
+  fun runCatching() {
+    lint()
+      .files(
+        kotlin(
+            """
+          package foo
+
+          class SomeClass {
+            val result = runCatching {}
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/foo/SomeClass.kt:4: Error: runCatching has hidden issues when used with coroutines as it catches and doesn't rethrow CancellationException. This can interfere with coroutines cancellation handling! Prefer catching specific exceptions based on the current case. [DenyListedApi]
+          val result = runCatching {}
+                       ~~~~~~~~~~~~~~
+        1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
   companion object {
     private val OBSERVABLE_STUB =
       java(


### PR DESCRIPTION
###  Summary

Adding `runCatching` to the deny list as it behaves the same as a try/catch catching any throwable, potentially catching unintended exceptions. Which when used with coroutines it catches and doesn't rethrow CancellationExceptions. 

