### PR TITLE
Port ExceptionMessageDetector check from AOSP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,10 +34,8 @@ allprojects {
       endWithNewline()
     }
 
-    val externalSourceGlobs = arrayOf(
-      "**/denylistedapis/*.kt",
-      "**/ExceptionMessageDetector*.kt",
-    )
+    val externalSourceGlobs =
+      arrayOf("**/denylistedapis/*.kt", "**/ExceptionMessageDetector*.kt", "**/util/Names.kt")
 
     kotlin {
       target("**/*.kt")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,17 +33,23 @@ allprojects {
       trimTrailingWhitespace()
       endWithNewline()
     }
+
+    val externalSourceGlobs = arrayOf(
+      "**/denylistedapis/*.kt",
+      "**/ExceptionMessageDetector*.kt",
+    )
+
     kotlin {
       target("**/*.kt")
       ktfmt(ktfmtVersion).googleStyle()
       trimTrailingWhitespace()
       endWithNewline()
       licenseHeaderFile(rootProject.file("spotless/spotless.kt"))
-      targetExclude("**/spotless.kt", "**/denylistedapis/*.kt")
+      targetExclude("**/spotless.kt", *externalSourceGlobs)
     }
     // Externally adapted sources that should preserve their license header
     format("kotlinExternal", KotlinExtension::class.java) {
-      target("**/denylistedapis/*.kt")
+      target(*externalSourceGlobs)
       ktfmt(ktfmtVersion).googleStyle()
       trimTrailingWhitespace()
       endWithNewline()

--- a/slack-lint-checks/src/main/java/slack/lint/ExceptionMessageDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/ExceptionMessageDetector.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiMethod
+import java.util.EnumSet
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.getParameterForArgument
+import slack.lint.util.Name
+import slack.lint.util.Package
+import slack.lint.util.isInPackageName
+
+class ExceptionMessageDetector : Detector(), SourceCodeScanner {
+
+  override fun getApplicableMethodNames(): List<String> =
+    listOf(Check, CheckNotNull, Require, RequireNotNull).map { it.shortName }
+  override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
+
+    // We ignore other functions with the same name.
+    if (!method.isInPackageName(KotlinPackage)) return
+
+    val lazyMessage = node.valueArguments
+      .find { node.getParameterForArgument(it)?.name == "lazyMessage" }
+    if (lazyMessage == null) {
+      context.report(
+        ISSUE,
+        node,
+        context.getNameLocation(node),
+        "Please specify a lazyMessage param for ${node.methodName}",
+      )
+    }
+  }
+
+  internal companion object {
+    val KotlinPackage = Package("kotlin")
+    val Check = Name(KotlinPackage, "check")
+    val CheckNotNull = Name(KotlinPackage, "checkNotNull")
+    val Require = Name(KotlinPackage, "require")
+    val RequireNotNull = Name(KotlinPackage, "requireNotNull")
+    val ISSUE = Issue.create(
+      id = "ExceptionMessage",
+      briefDescription = "Please provide a string for the lazyMessage parameter",
+      explanation = """
+                Calls to check(), checkNotNull(), require() and requireNotNull() should
+                include a message string that can be used to debug issues experienced
+                by users.
+
+                When we read user-supplied logs, the line numbers are sometimes not
+                sufficient to determine the cause of a bug. Inline functions can
+                sometimes make it hard to determine which file threw an exception.
+                Consider supplying a lazyMessage parameter to identify the check()
+                or require() call.
+            """,
+      category = Category.CORRECTNESS,
+      priority = 3,
+      severity = Severity.ERROR,
+      implementation = Implementation(
+        ExceptionMessageDetector::class.java,
+        EnumSet.of(Scope.JAVA_FILE)
+      )
+    )
+  }
+}

--- a/slack-lint-checks/src/main/java/slack/lint/ExceptionMessageDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/ExceptionMessageDetector.kt
@@ -17,14 +17,11 @@ package slack.lint
 
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Detector
-import com.android.tools.lint.detector.api.Implementation
 import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.JavaContext
-import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.intellij.psi.PsiMethod
-import java.util.EnumSet
 import org.jetbrains.uast.UCallExpression
 import org.jetbrains.uast.getParameterForArgument
 import slack.lint.util.Name
@@ -36,13 +33,14 @@ class ExceptionMessageDetector : Detector(), SourceCodeScanner {
 
   override fun getApplicableMethodNames(): List<String> =
     listOf(Check, CheckNotNull, Require, RequireNotNull).map { it.shortName }
+
   override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
 
     // We ignore other functions with the same name.
     if (!method.isInPackageName(KotlinPackage)) return
 
-    val lazyMessage = node.valueArguments
-      .find { node.getParameterForArgument(it)?.name == "lazyMessage" }
+    val lazyMessage =
+      node.valueArguments.find { node.getParameterForArgument(it)?.name == "lazyMessage" }
     if (lazyMessage == null) {
       context.report(
         ISSUE,
@@ -59,10 +57,12 @@ class ExceptionMessageDetector : Detector(), SourceCodeScanner {
     val CheckNotNull = Name(KotlinPackage, "checkNotNull")
     val Require = Name(KotlinPackage, "require")
     val RequireNotNull = Name(KotlinPackage, "requireNotNull")
-    val ISSUE = Issue.create(
-      id = "ExceptionMessage",
-      briefDescription = "Please provide a string for the lazyMessage parameter",
-      explanation = """
+    val ISSUE =
+      Issue.create(
+        id = "ExceptionMessage",
+        briefDescription = "Please provide a string for the lazyMessage parameter",
+        explanation =
+          """
                 Calls to check(), checkNotNull(), require() and requireNotNull() should
                 include a message string that can be used to debug issues experienced
                 by users.
@@ -73,10 +73,10 @@ class ExceptionMessageDetector : Detector(), SourceCodeScanner {
                 Consider supplying a lazyMessage parameter to identify the check()
                 or require() call.
             """,
-      category = Category.CORRECTNESS,
-      priority = 3,
-      severity = Severity.ERROR,
-      implementation = sourceImplementation<ExceptionMessageDetector>()
-    )
+        category = Category.CORRECTNESS,
+        priority = 3,
+        severity = Severity.ERROR,
+        implementation = sourceImplementation<ExceptionMessageDetector>()
+      )
   }
 }

--- a/slack-lint-checks/src/main/java/slack/lint/ExceptionMessageDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/ExceptionMessageDetector.kt
@@ -30,6 +30,7 @@ import org.jetbrains.uast.getParameterForArgument
 import slack.lint.util.Name
 import slack.lint.util.Package
 import slack.lint.util.isInPackageName
+import slack.lint.util.sourceImplementation
 
 class ExceptionMessageDetector : Detector(), SourceCodeScanner {
 
@@ -75,10 +76,7 @@ class ExceptionMessageDetector : Detector(), SourceCodeScanner {
       category = Category.CORRECTNESS,
       priority = 3,
       severity = Severity.ERROR,
-      implementation = Implementation(
-        ExceptionMessageDetector::class.java,
-        EnumSet.of(Scope.JAVA_FILE)
-      )
+      implementation = sourceImplementation<ExceptionMessageDetector>()
     )
   }
 }

--- a/slack-lint-checks/src/main/java/slack/lint/SlackIssueRegistry.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/SlackIssueRegistry.kt
@@ -67,5 +67,6 @@ class SlackIssueRegistry : IssueRegistry() {
       WrongResourceImportAliasDetector.ISSUE,
       DenyListedApiDetector.ISSUE,
       ParcelizeFunctionPropertyDetector.ISSUE,
+      ExceptionMessageDetector.ISSUE,
     )
 }

--- a/slack-lint-checks/src/main/java/slack/lint/util/LintUtils.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/util/LintUtils.kt
@@ -345,17 +345,13 @@ internal fun slackLintErrorLog(message: String) {
   }
 }
 
-/**
- * Returns whether [this] has [packageName] as its package name.
- */
+/** Returns whether [this] has [packageName] as its package name. */
 internal fun PsiMethod.isInPackageName(packageName: PackageName): Boolean {
   val actual = (containingFile as? PsiJavaFile)?.packageName
   return packageName.javaPackageName == actual
 }
 
-/**
- * Whether this [PsiMethod] returns Unit
- */
+/** Whether this [PsiMethod] returns Unit */
 internal val PsiMethod.returnsUnit
   get() = returnType.isVoidOrUnit
 
@@ -367,4 +363,3 @@ internal val PsiMethod.returnsUnit
  */
 internal val PsiType?.isVoidOrUnit
   get() = this == PsiType.VOID || this?.canonicalText == "kotlin.Unit"
-

--- a/slack-lint-checks/src/main/java/slack/lint/util/LintUtils.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/util/LintUtils.kt
@@ -25,6 +25,8 @@ import com.android.tools.lint.detector.api.isKotlin
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiModifierListOwner
 import com.intellij.psi.PsiType
 import com.intellij.psi.PsiWildcardType
@@ -342,3 +344,27 @@ internal fun slackLintErrorLog(message: String) {
     System.err.println("SlackLint: $message")
   }
 }
+
+/**
+ * Returns whether [this] has [packageName] as its package name.
+ */
+internal fun PsiMethod.isInPackageName(packageName: PackageName): Boolean {
+  val actual = (containingFile as? PsiJavaFile)?.packageName
+  return packageName.javaPackageName == actual
+}
+
+/**
+ * Whether this [PsiMethod] returns Unit
+ */
+internal val PsiMethod.returnsUnit
+  get() = returnType.isVoidOrUnit
+
+/**
+ * Whether this [PsiType] is `void` or [Unit]
+ *
+ * In Kotlin 1.6 some expressions now explicitly return [Unit] instead of just being [PsiType.VOID],
+ * so this returns whether this type is either.
+ */
+internal val PsiType?.isVoidOrUnit
+  get() = this == PsiType.VOID || this?.canonicalText == "kotlin.Unit"
+

--- a/slack-lint-checks/src/main/java/slack/lint/util/Names.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/util/Names.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint.util
+
+import kotlinx.metadata.ClassName
+
+/**
+ * Represents a qualified package
+ *
+ * @property segments the segments representing the package
+ */
+internal class PackageName(val segments: List<String>) {
+  /** The Java-style package name for this [Name], separated with `.` */
+  val javaPackageName: String
+    get() = segments.joinToString(".")
+}
+
+/**
+ * Represents the qualified name for an element
+ *
+ * @property pkg the package for this element
+ * @property nameSegments the segments representing the element - there can be multiple in the case
+ *   of nested classes.
+ */
+internal class Name(private val pkg: PackageName, private val nameSegments: List<String>) {
+  /** The short name for this [Name] */
+  val shortName: String
+    get() = nameSegments.last()
+
+  /** The Java-style fully qualified name for this [Name], separated with `.` */
+  val javaFqn: String
+    get() = pkg.segments.joinToString(".", postfix = ".") + nameSegments.joinToString(".")
+
+  /**
+   * The [ClassName] for use with kotlinx.metadata. Note that in kotlinx.metadata the actual type
+   * might be different from the underlying JVM type, for example: kotlin/Int -> java/lang/Integer
+   */
+  val kmClassName: ClassName
+    get() = pkg.segments.joinToString("/", postfix = "/") + nameSegments.joinToString(".")
+
+  /** The [PackageName] of this element. */
+  val packageName: PackageName
+    get() = pkg
+}
+
+/** @return a [PackageName] with a Java-style (separated with `.`) [packageName]. */
+internal fun Package(packageName: String): PackageName = PackageName(packageName.split("."))
+
+/** @return a [PackageName] with a Java-style (separated with `.`) [packageName]. */
+internal fun Package(packageName: PackageName, shortName: String): PackageName =
+  PackageName(packageName.segments + shortName.split("."))
+
+/** @return a [Name] with the provided [pkg] and Java-style (separated with `.`) [shortName]. */
+internal fun Name(pkg: PackageName, shortName: String): Name = Name(pkg, shortName.split("."))

--- a/slack-lint-checks/src/test/java/slack/lint/ExceptionMessageDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/ExceptionMessageDetectorTest.kt
@@ -1,0 +1,565 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package slack.lint
+
+import org.junit.Test
+
+class ExceptionMessageDetectorTest : BaseSlackLintTest() {
+  override fun getDetector() = ExceptionMessageDetector()
+
+  override fun getIssues() = listOf(ExceptionMessageDetector.ISSUE)
+
+  @Test
+  fun checkWithMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        check(true) {"Message"}
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun checkWithNamedParameterValue() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        check(value = true) {"Message"}
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun checkWithNamedParameterMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        check(true, lazyMessage = {"Message"})
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun checkWithNamedParameterValueAndMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        check(value = true, lazyMessage = {"Message"})
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun checkWithNamedParameterValueAndMessageReversed() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        check(lazyMessage = {"Message"}, value = true)
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun checkWithoutMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        check(true)
+                    }
+                    """
+        ),
+      )
+      .run()
+      .expect(
+        """
+                    src/test/test.kt:5: Error: Please specify a lazyMessage param for check [ExceptionMessage]
+                                            check(true)
+                                            ~~~~~
+                    1 errors, 0 warnings
+                """
+      )
+  }
+
+  @Test
+  fun checkFromDifferentPackageWithoutMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        check(true)
+                    }
+
+                    fun check(boolean: Boolean) {}
+                    """
+        ),
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun checkNotNullWithMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        checkNotNull(null) {"Message"}
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun checkNotNullWithNamedParameterValue() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        checkNotNull(value = null) {"Message"}
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun checkNotNullWithNamedParameterMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        checkNotNull(null, lazyMessage = {"Message"})
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun checkNotNullWithNamedParameterValueAndMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        checkNotNull(value = null, lazyMessage = {"Message"})
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun checkNotNullWithNamedParameterValueAndMessageReversed() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        checkNotNull(lazyMessage = {"Message"}, value = null)
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun checkNotNullWithoutMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        checkNotNull(null)
+                    }
+                    """
+        ),
+      )
+      .run()
+      .expect(
+        """
+                    src/test/test.kt:5: Error: Please specify a lazyMessage param for checkNotNull [ExceptionMessage]
+                                            checkNotNull(null)
+                                            ~~~~~~~~~~~~
+                    1 errors, 0 warnings
+                """
+      )
+  }
+
+  @Test
+  fun checkNotNullFromDifferentPackageWithoutMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        checkNotNull(null)
+                    }
+
+                    fun checkNotNull(value: Any?) {}
+                    """
+        ),
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun requireWithMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        require(true) {"Message"}
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun requireWithNamedParameterValue() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        require(value = true) {"Message"}
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun requireWithNamedParameterMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        require(true, lazyMessage = {"Message"})
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun requireWithNamedParameterValueAndMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        require(value = true, lazyMessage = {"Message"})
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun requireWithNamedParameterValueAndMessageReversed() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        require(lazyMessage = {"Message"}, value = true)
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun requireWithoutMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        require(true)
+                    }
+                    """
+        ),
+      )
+      .run()
+      .expect(
+        """
+                    src/test/test.kt:5: Error: Please specify a lazyMessage param for require [ExceptionMessage]
+                                            require(true)
+                                            ~~~~~~~
+                    1 errors, 0 warnings
+                """
+      )
+  }
+
+  @Test
+  fun requireFromDifferentPackageWithoutMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        require(true)
+                    }
+
+                    fun require(boolean: Boolean) {}
+                    """
+        ),
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun requireNotNullWithMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        requireNotNull(null) {"Message"}
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun requireNotNullWithNamedParameterValue() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        requireNotNull(value = null) {"Message"}
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun requireNotNullWithNamedParameterMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        requireNotNull(null, lazyMessage = {"Message"})
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun requireNotNullWithNamedParameterValueAndMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        requireNotNull(value = null, lazyMessage = {"Message"})
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun requireNotNullWithNamedParameterValueAndMessageReversed() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        requireNotNull(lazyMessage = {"Message"}, value = null)
+                    }
+                    """
+        )
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun requireNotNullWithoutMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        requireNotNull(null)
+                    }
+                    """
+        ),
+      )
+      .run()
+      .expect(
+        """
+                    src/test/test.kt:5: Error: Please specify a lazyMessage param for requireNotNull [ExceptionMessage]
+                                            requireNotNull(null)
+                                            ~~~~~~~~~~~~~~
+                    1 errors, 0 warnings
+                """
+      )
+  }
+
+  @Test
+  fun requireNotNullFromDifferentPackageWithoutMessage() {
+    lint()
+      .files(
+        kotlin(
+          """
+                    package test
+
+                    fun content() {
+                        requireNotNull(null)
+                    }
+
+                    fun requireNotNull(value: Any?) {}
+                    """
+        ),
+      )
+      .run()
+      .expectClean()
+  }
+}


### PR DESCRIPTION
Borrowed from https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/lint/internal-lint-checks/src/main/java/androidx/compose/lint/ExceptionMessageDetector.kt