### PR TITLE
Add mock report option to MockDetector

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/mocking/MockDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/mocking/MockDetector.kt
@@ -7,7 +7,6 @@ import com.android.tools.lint.detector.api.BooleanOption
 import com.android.tools.lint.detector.api.Context
 import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.JavaContext
-import com.android.tools.lint.detector.api.PartialResult
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.android.tools.lint.detector.api.StringOption
 import com.android.tools.lint.detector.api.isJava
@@ -15,6 +14,11 @@ import com.android.tools.lint.detector.api.isKotlin
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiClassType
 import com.intellij.util.containers.map2Array
+import kotlin.io.path.bufferedWriter
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createFile
+import kotlin.io.path.deleteExisting
+import kotlin.io.path.exists
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.uast.UAnnotated
 import org.jetbrains.uast.UCallExpression
@@ -28,12 +32,6 @@ import slack.lint.mocking.MockDetector.TypeChecker
 import slack.lint.util.MetadataJavaEvaluator
 import slack.lint.util.OptionLoadingDetector
 import slack.lint.util.StringSetLintOption
-import java.nio.file.Files
-import kotlin.io.path.bufferedWriter
-import kotlin.io.path.createDirectories
-import kotlin.io.path.createFile
-import kotlin.io.path.deleteExisting
-import kotlin.io.path.exists
 
 private data class MockFactory(
   val declarationContainer: String,
@@ -234,9 +232,7 @@ constructor(
       // TODO use createParentDirectories() when we upgrade to Kotlin 1.9
       outputFile.parent.createDirectories()
       outputFile.createFile()
-      outputFile.bufferedWriter().use {
-        it.write(reports.sorted().joinToString("\n"))
-      }
+      outputFile.bufferedWriter().use { it.write(reports.sorted().joinToString("\n")) }
     }
     reports.clear()
   }

--- a/slack-lint-checks/src/main/java/slack/lint/mocking/MockDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/mocking/MockDetector.kt
@@ -3,8 +3,11 @@
 package slack.lint.mocking
 
 import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.BooleanOption
+import com.android.tools.lint.detector.api.Context
 import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.PartialResult
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.android.tools.lint.detector.api.StringOption
 import com.android.tools.lint.detector.api.isJava
@@ -25,6 +28,12 @@ import slack.lint.mocking.MockDetector.TypeChecker
 import slack.lint.util.MetadataJavaEvaluator
 import slack.lint.util.OptionLoadingDetector
 import slack.lint.util.StringSetLintOption
+import java.nio.file.Files
+import kotlin.io.path.bufferedWriter
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createFile
+import kotlin.io.path.deleteExisting
+import kotlin.io.path.exists
 
 private data class MockFactory(
   val declarationContainer: String,
@@ -43,8 +52,11 @@ class MockDetector
 constructor(
   private val mockAnnotationsOption: StringSetLintOption = StringSetLintOption(MOCK_ANNOTATIONS),
   private val mockFactoriesOption: StringSetLintOption = StringSetLintOption(MOCK_FACTORIES),
+  private val mockReport: BooleanOption = MOCK_REPORT,
 ) : OptionLoadingDetector(mockAnnotationsOption, mockFactoriesOption), SourceCodeScanner {
   companion object {
+
+    internal const val MOCK_REPORT_PATH = "build/reports/mockdetector/mocks.txt"
 
     internal val MOCK_ANNOTATIONS =
       StringOption(
@@ -62,6 +74,14 @@ constructor(
         "A comma-separated list of mock factories (org.mockito.Mockito#methodName)."
       )
 
+    internal val MOCK_REPORT =
+      BooleanOption(
+        "mock-report",
+        "If enabled, writes a mock report to <project-dir>/$MOCK_REPORT_PATH.",
+        false,
+        "If enabled, writes a mock report to <project-dir>/$MOCK_REPORT_PATH. The format of the file is a newline-delimited list of qualified names of incorrectly mocked classes."
+      )
+
     private val TYPE_CHECKERS =
       listOf(
         // Loosely defined in the order of most likely to be hit
@@ -73,9 +93,12 @@ constructor(
         ObjectClassMockDetector,
         RecordClassMockDetector,
       )
-    private val OPTIONS = listOf(MOCK_ANNOTATIONS, MOCK_FACTORIES)
+    private val OPTIONS = listOf(MOCK_ANNOTATIONS, MOCK_FACTORIES, MOCK_REPORT)
     val ISSUES = TYPE_CHECKERS.map2Array { it.issue.setOptions(OPTIONS) }
   }
+
+  // A mapping of mocked types
+  private val reports = mutableListOf<String>()
 
   override fun getApplicableUastTypes() = listOf(UCallExpression::class.java, UField::class.java)
 
@@ -88,6 +111,8 @@ constructor(
           return null
         }
     val slackEvaluator = MetadataJavaEvaluator(context.file.name, context.evaluator)
+
+    val reportingEnabled = mockReport.getValue(context)
 
     val mockFactories: Map<String, Set<String>> =
       mockFactoriesOption.value
@@ -173,14 +198,22 @@ constructor(
         return mockAnnotationsOption.value.any { node.findAnnotation(it) != null }
       }
 
+      private fun addReport(type: PsiClass) {
+        if (reportingEnabled) {
+          type.qualifiedName?.let { reports += it }
+        }
+      }
+
       private fun checkMock(node: UElement, type: PsiClass) {
         for (checker in checkers) {
           val reason = checker.checkType(context, slackEvaluator, type)
           if (reason != null) {
+            addReport(type)
             context.report(checker.issue, context.getLocation(node), reason.reason)
             continue
           }
           val disallowedAnnotation = checker.annotations.find { type.hasAnnotation(it) } ?: continue
+          addReport(type)
           context.report(
             checker.issue,
             context.getLocation(node),
@@ -190,6 +223,22 @@ constructor(
         }
       }
     }
+  }
+
+  override fun afterCheckEachProject(context: Context) {
+    if (mockReport.getValue(context) && reports.isNotEmpty()) {
+      val outputFile = context.project.dir.toPath().resolve(MOCK_REPORT_PATH)
+      if (outputFile.exists()) {
+        outputFile.deleteExisting()
+      }
+      // TODO use createParentDirectories() when we upgrade to Kotlin 1.9
+      outputFile.parent.createDirectories()
+      outputFile.createFile()
+      outputFile.bufferedWriter().use {
+        it.write(reports.sorted().joinToString("\n"))
+      }
+    }
+    reports.clear()
   }
 
   interface TypeChecker {

--- a/slack-lint-checks/src/test/java/slack/lint/mocking/MockReportTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/mocking/MockReportTest.kt
@@ -1,0 +1,160 @@
+// Copyright (C) 2021 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.mocking
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import slack.lint.BaseSlackLintTest
+import slack.lint.mocking.MockDetector.Companion.MOCK_REPORT
+
+class MockReportTest : BaseSlackLintTest() {
+
+  @Rule @JvmField val tmpFolder = TemporaryFolder()
+
+  private val testClass =
+    kotlin(
+        """
+      package slack.test
+
+      data class TestClass(val foo: String, val list: List<TestClass> = emptyList())
+    """
+      )
+      .indented()
+
+  override fun getDetector() = MockDetector()
+
+  override fun getIssues() = MockDetector.ISSUES.toList()
+
+  @Test
+  fun kotlinTests() {
+    val source =
+      kotlin(
+          "test/test/slack/test/TestClass.kt",
+          """
+          package slack.test
+
+          import org.mockito.Mock
+          import org.mockito.Spy
+          import slack.test.mockito.mock
+
+          class MyTests {
+            @Mock lateinit var fieldMock: TestClass
+            @Spy lateinit var fieldSpy: TestClass
+
+            fun example() {
+              val localMock1 = org.mockito.Mockito.mock(TestClass::class.java)
+              val localSpy1 = org.mockito.Mockito.spy(localMock1)
+              val localMock2 = mock<TestClass>()
+              val classRef = TestClass::class.java
+              val localMock3 = org.mockito.Mockito.mock(classRef)
+
+              val dynamicMock = mock<TestClass> {
+
+              }
+              val assigned: TestClass = mock()
+              val fake = TestClass("this is fine")
+
+              // Extra tests for location reporting
+              val unnecessaryMockedValues = TestClass(
+                "This is fine",
+                mock()
+              )
+              val unnecessaryNestedMockedValues = TestClass(
+                "This is fine",
+                listOf(mock())
+              )
+              val withNamedArgs = TestClass(
+                foo = "This is fine",
+                list = listOf(mock())
+              )
+            }
+          }
+        """
+        )
+        .indented()
+
+    val task =
+      lint()
+        .rootDirectory(tmpFolder.root)
+        .files(*mockFileStubs(), testClass, source)
+        .configureOption(MOCK_REPORT, true)
+
+    task.run()
+
+    val reports = tmpFolder.root.toPath().resolve("default/app/${MockDetector.MOCK_REPORT_PATH}")
+    assertThat(reports.exists()).isTrue()
+    assertThat(reports.readText())
+      .isEqualTo(
+        """
+        java.util.List
+        slack.test.TestClass
+        slack.test.TestClass
+        slack.test.TestClass
+        slack.test.TestClass
+        slack.test.TestClass
+        slack.test.TestClass
+        slack.test.TestClass
+        slack.test.TestClass
+        slack.test.TestClass
+        slack.test.TestClass
+      """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun javaTests() {
+    val source =
+      java(
+          "test/test/slack/test/TestClass.java",
+          """
+          package slack.test;
+
+          import org.mockito.Mock;
+          import org.mockito.Spy;
+          import static org.mockito.Mockito.mock;
+          import static org.mockito.Mockito.spy;
+
+          class MyTests {
+            @Mock TestClass fieldMock;
+            @Spy TestClass fieldSpy;
+
+            public void example() {
+              TestClass localMock = mock(TestClass.class);
+              TestClass localSpy = spy(localMock);
+              Class<TestClass> classRef = TestClass.class;
+              TestClass localMock2 = mock(classRef);
+              TestClass fake = new TestClass("this is fine");
+            }
+          }
+        """
+        )
+        .indented()
+
+    val task =
+      lint()
+        .rootDirectory(tmpFolder.root)
+        .files(*mockFileStubs(), testClass, source)
+        .configureOption(MOCK_REPORT, true)
+
+    task.run()
+
+    val reports = tmpFolder.root.toPath().resolve("default/app/${MockDetector.MOCK_REPORT_PATH}")
+    assertThat(reports.exists()).isTrue()
+    assertThat(reports.readText())
+      .isEqualTo(
+        """
+        slack.test.TestClass
+        slack.test.TestClass
+        slack.test.TestClass
+        slack.test.TestClass
+        slack.test.TestClass
+      """
+          .trimIndent()
+      )
+  }
+}


### PR DESCRIPTION
This adds a new on-demand feature to write a report file of incorrectly mocked types. The idea with this is that we can write a tool that scrapes this output file separately after a lint run and aggregate the most commonly mocked types, and use that as a heuristic of what should be prioritized in writing fakes.