### PR TITLE
Add an extra annotation-based check for value classes

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/util/LintUtils.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/util/LintUtils.kt
@@ -68,9 +68,11 @@ internal fun PsiClass.implements(
   }
 }
 
-/** @return whether or not [owner] is a Kotlin `value` class. */
+/** @return whether [owner] is a Kotlin `value` class. */
 internal fun JavaEvaluator.isValueClass(owner: PsiModifierListOwner?): Boolean {
-  return hasModifier(owner, KtTokens.VALUE_KEYWORD)
+  // Check the annotation for JvmInline as a shorter check
+  return owner?.hasAnnotation("kotlin.jvm.JvmInline") == true ||
+    hasModifier(owner, KtTokens.VALUE_KEYWORD)
 }
 
 internal fun UClass.isInnerClass(evaluator: JavaEvaluator): Boolean {


### PR DESCRIPTION
This adds an extra layer to the swiss cheese to try to capture these types. Since kotlin 1.5, kotlinc will generate this annotation onto JVM value classes.

Note we don't enable this check in our registry yet due to #88