### PR TITLE
Add support for mock report modes + CSV format

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/mocking/MockDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/mocking/MockDetector.kt
@@ -112,9 +112,9 @@ constructor(
 
     val reportingMode = reportMode(context)
 
-    val reportErrorsEnabled =
+    val reportErrors =
       reportingMode == MockReportMode.ALL || reportingMode == MockReportMode.ERRORS
-    val reportAllEnabled = reportingMode == MockReportMode.ALL
+    val reportAll = reportingMode == MockReportMode.ALL
 
     val mockFactories: Map<String, Set<String>> =
       mockFactoriesOption.value
@@ -201,7 +201,7 @@ constructor(
       }
 
       private fun addReport(type: PsiClass, isError: Boolean) {
-        if (reportAllEnabled || (isError && reportErrorsEnabled)) {
+        if (reportAll || (isError && reportErrors)) {
           type.qualifiedName?.let { reports += (it to isError) }
         }
       }
@@ -212,7 +212,7 @@ constructor(
           if (reason != null) {
             addReport(type, isError = true)
             context.report(checker.issue, context.getLocation(node), reason.reason)
-            continue
+            return
           }
           val disallowedAnnotation = checker.annotations.find { type.hasAnnotation(it) } ?: continue
           addReport(type, isError = true)

--- a/slack-lint-checks/src/main/java/slack/lint/mocking/MockDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/mocking/MockDetector.kt
@@ -3,7 +3,6 @@
 package slack.lint.mocking
 
 import com.android.tools.lint.client.api.UElementHandler
-import com.android.tools.lint.detector.api.BooleanOption
 import com.android.tools.lint.detector.api.Context
 import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.JavaContext
@@ -14,6 +13,7 @@ import com.android.tools.lint.detector.api.isKotlin
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiClassType
 import com.intellij.util.containers.map2Array
+import java.util.Locale
 import kotlin.io.path.bufferedWriter
 import kotlin.io.path.createDirectories
 import kotlin.io.path.createFile
@@ -32,7 +32,6 @@ import slack.lint.mocking.MockDetector.TypeChecker
 import slack.lint.util.MetadataJavaEvaluator
 import slack.lint.util.OptionLoadingDetector
 import slack.lint.util.StringSetLintOption
-import java.util.Locale
 
 private data class MockFactory(
   val declarationContainer: String,
@@ -113,7 +112,8 @@ constructor(
 
     val reportingMode = reportMode(context)
 
-    val reportErrorsEnabled = reportingMode == MockReportMode.ALL || reportingMode == MockReportMode.ERRORS
+    val reportErrorsEnabled =
+      reportingMode == MockReportMode.ALL || reportingMode == MockReportMode.ERRORS
     val reportAllEnabled = reportingMode == MockReportMode.ALL
 
     val mockFactories: Map<String, Set<String>> =
@@ -229,8 +229,7 @@ constructor(
   }
 
   private fun reportMode(context: Context): MockReportMode {
-    return mockReport.getValue(context)
-      ?.let { MockReportMode.valueOf(it.uppercase(Locale.US)) }
+    return mockReport.getValue(context)?.let { MockReportMode.valueOf(it.uppercase(Locale.US)) }
       ?: MockReportMode.NONE
   }
 

--- a/slack-lint-checks/src/main/java/slack/lint/mocking/MockDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/mocking/MockDetector.kt
@@ -112,8 +112,7 @@ constructor(
 
     val reportingMode = reportMode(context)
 
-    val reportErrors =
-      reportingMode == MockReportMode.ALL || reportingMode == MockReportMode.ERRORS
+    val reportErrors = reportingMode == MockReportMode.ALL || reportingMode == MockReportMode.ERRORS
     val reportAll = reportingMode == MockReportMode.ALL
 
     val mockFactories: Map<String, Set<String>> =

--- a/slack-lint-checks/src/test/java/slack/lint/mocking/MockReportTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/mocking/MockReportTest.kt
@@ -11,8 +11,7 @@ import org.junit.rules.TemporaryFolder
 import slack.lint.BaseSlackLintTest
 import slack.lint.mocking.MockDetector.Companion.MOCK_REPORT
 
-class
-MockReportTest : BaseSlackLintTest() {
+class MockReportTest : BaseSlackLintTest() {
 
   @Rule @JvmField val tmpFolder = TemporaryFolder()
 

--- a/slack-lint-checks/src/test/java/slack/lint/mocking/MockReportTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/mocking/MockReportTest.kt
@@ -11,7 +11,8 @@ import org.junit.rules.TemporaryFolder
 import slack.lint.BaseSlackLintTest
 import slack.lint.mocking.MockDetector.Companion.MOCK_REPORT
 
-class MockReportTest : BaseSlackLintTest() {
+class
+MockReportTest : BaseSlackLintTest() {
 
   @Rule @JvmField val tmpFolder = TemporaryFolder()
 
@@ -81,7 +82,7 @@ class MockReportTest : BaseSlackLintTest() {
       lint()
         .rootDirectory(tmpFolder.root)
         .files(*mockFileStubs(), testClass, source)
-        .configureOption(MOCK_REPORT, true)
+        .configureOption(MOCK_REPORT, MockDetector.MockReportMode.ERRORS.name)
 
     task.run()
 
@@ -90,17 +91,18 @@ class MockReportTest : BaseSlackLintTest() {
     assertThat(reports.readText())
       .isEqualTo(
         """
-        java.util.List
-        slack.test.TestClass
-        slack.test.TestClass
-        slack.test.TestClass
-        slack.test.TestClass
-        slack.test.TestClass
-        slack.test.TestClass
-        slack.test.TestClass
-        slack.test.TestClass
-        slack.test.TestClass
-        slack.test.TestClass
+        type,isError
+        java.util.List,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
       """
           .trimIndent()
       )
@@ -139,7 +141,7 @@ class MockReportTest : BaseSlackLintTest() {
       lint()
         .rootDirectory(tmpFolder.root)
         .files(*mockFileStubs(), testClass, source)
-        .configureOption(MOCK_REPORT, true)
+        .configureOption(MOCK_REPORT, MockDetector.MockReportMode.ERRORS.name)
 
     task.run()
 
@@ -148,11 +150,12 @@ class MockReportTest : BaseSlackLintTest() {
     assertThat(reports.readText())
       .isEqualTo(
         """
-        slack.test.TestClass
-        slack.test.TestClass
-        slack.test.TestClass
-        slack.test.TestClass
-        slack.test.TestClass
+        type,isError
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
       """
           .trimIndent()
       )

--- a/slack-lint-checks/src/test/java/slack/lint/mocking/MockReportTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/mocking/MockReportTest.kt
@@ -159,4 +159,103 @@ class MockReportTest : BaseSlackLintTest() {
           .trimIndent()
       )
   }
+
+  @Test
+  fun allMode() {
+    val source =
+      kotlin(
+          "test/test/slack/test/TestClass.kt",
+          """
+          package slack.test
+
+          import org.mockito.Mock
+          import org.mockito.Spy
+          import slack.test.mockito.mock
+          import java.lang.Runnable
+
+          interface ExampleInterface
+
+          class MyTests {
+            @Mock lateinit var fieldMock: TestClass
+            @Spy lateinit var fieldSpy: TestClass
+            @Mock lateinit var nonErrorMock: ExampleInterface
+            @Spy lateinit var nonErrorSpy: java.lang.ExampleInterface
+
+            fun example() {
+              val localMock1 = org.mockito.Mockito.mock(TestClass::class.java)
+              val localSpy1 = org.mockito.Mockito.spy(localMock1)
+              val localMock2 = mock<TestClass>()
+              val classRef = TestClass::class.java
+              val localMock3 = org.mockito.Mockito.mock(classRef)
+              val nonErrorMock1 = org.mockito.Mockito.mock(ExampleInterface::class.java)
+              val nonErrorSpy1 = org.mockito.Mockito.spy(nonErrorMock1)
+              val nonErrorMock2 = mock<ExampleInterface>()
+              val classRef = ExampleInterface::class.java
+              val nonErrorMock3 = org.mockito.Mockito.mock(classRef)
+
+              val dynamicMock = mock<TestClass> {
+
+              }
+              val dynamicNonErrorMock = mock<ExampleInterface> {
+
+              }
+              val assigned: TestClass = mock()
+              val assignedNonError: ExampleInterface = mock()
+              val fake = TestClass("this is fine")
+
+              // Extra tests for location reporting
+              val unnecessaryMockedValues = TestClass(
+                "This is fine",
+                mock()
+              )
+              val unnecessaryNestedMockedValues = TestClass(
+                "This is fine",
+                listOf(mock())
+              )
+              val withNamedArgs = TestClass(
+                foo = "This is fine",
+                list = listOf(mock())
+              )
+            }
+          }
+        """
+        )
+        .indented()
+
+    val task =
+      lint()
+        .rootDirectory(tmpFolder.root)
+        .files(*mockFileStubs(), testClass, source)
+        .configureOption(MOCK_REPORT, MockDetector.MockReportMode.ALL.name)
+
+    task.run()
+
+    val reports = tmpFolder.root.toPath().resolve("default/app/${MockDetector.MOCK_REPORT_PATH}")
+    assertThat(reports.exists()).isTrue()
+    assertThat(reports.readText())
+      .isEqualTo(
+        """
+        type,isError
+        java.util.List,true
+        slack.test.ExampleInterface,false
+        slack.test.ExampleInterface,false
+        slack.test.ExampleInterface,false
+        slack.test.ExampleInterface,false
+        slack.test.ExampleInterface,false
+        slack.test.ExampleInterface,false
+        slack.test.ExampleInterface,false
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+        slack.test.TestClass,true
+      """
+          .trimIndent()
+      )
+  }
 }


### PR DESCRIPTION
This allows us to optionally include _all_ mocked types found in mock report files, not just errors. We'd never report non-errors as lint errors, but this gives us some useful infrastructure to reuse. Especially important as not all mock type checkers are error severity.