### PR TITLE
Add LintKotlinVersionCheckTest

### DIFF
--- a/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
@@ -57,7 +57,12 @@ class LintKotlinVersionCheckTest : BaseSlackLintTest() {
         override fun visitMethod(node: UMethod) {
           if (KotlinVersion.CURRENT == EXPECTED_VERSION) {
             // Report something anyway to ensure our lint was correctly picked up at least
-            context.report(ISSUE, node, context.getLocation(node), "Kotlin version matched expected one")
+            context.report(
+              ISSUE,
+              node,
+              context.getLocation(node),
+              "Kotlin version matched expected one"
+            )
           } else {
             context.report(
               ISSUE,

--- a/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
@@ -40,7 +40,7 @@ class LintKotlinVersionCheckTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-          src/test/test.kt:3: Error: Kotlin version was expected [KotlinVersion]
+          src/test/test.kt:3: Error: Kotlin version matched expected one [KotlinVersion]
           fun main() {
           ^
           1 errors, 0 warnings
@@ -57,7 +57,7 @@ class LintKotlinVersionCheckTest : BaseSlackLintTest() {
         override fun visitMethod(node: UMethod) {
           if (KotlinVersion.CURRENT == EXPECTED_VERSION) {
             // Report something anyway to ensure our lint was correctly picked up at least
-            context.report(ISSUE, node, context.getLocation(node), "Kotlin version was expected")
+            context.report(ISSUE, node, context.getLocation(node), "Kotlin version matched expected one")
           } else {
             context.report(
               ISSUE,

--- a/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
@@ -27,14 +27,15 @@ class LintKotlinVersionCheckTest : BaseSlackLintTest() {
     lint()
       .files(
         kotlin(
-          """
+            """
             package test
 
             fun main() {
               println("Hello, world!")
             }
           """
-        )
+          )
+          .indented()
       )
       .run()
       .expect(
@@ -75,7 +76,7 @@ class LintKotlinVersionCheckTest : BaseSlackLintTest() {
     }
 
     companion object {
-      private val EXPECTED_VERSION = KotlinVersion(1, 9, 20)
+      private val EXPECTED_VERSION = KotlinVersion(1, 9, 0)
       val ISSUE =
         Issue.create(
           "KotlinVersion",

--- a/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
@@ -2,16 +2,84 @@
 // SPDX-License-Identifier: Apache-2.0
 package slack.lint
 
-import com.google.common.truth.Truth.assertThat
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.uast.UMethod
 import org.junit.Test
+import slack.lint.util.sourceImplementation
 
 /**
  * Lint chases Kotlin versions differently than what we declare our build with. This test is just
  * here to catch those for our own awareness and should be updated whenever lint updates its own.
  */
-class LintKotlinVersionCheckTest {
+class LintKotlinVersionCheckTest : BaseSlackLintTest() {
+
+  override fun getDetector(): Detector = KotlinVersionDetector()
+
+  override fun getIssues() = listOf(KotlinVersionDetector.ISSUE)
+
   @Test
   fun check() {
-    assertThat(KotlinVersion.CURRENT).isEqualTo(KotlinVersion(1, 9, 20))
+    lint()
+      .files(
+        kotlin(
+          """
+            package test
+
+            fun main() {
+              println("Hello, world!")
+            }
+          """
+            .trimIndent()
+        )
+      )
+      .run()
+      .expect(
+        """
+          src/test/test.kt:3: Error: Kotlin version was expected [KotlinVersion]
+          fun main() {
+          ^
+          1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
+  class KotlinVersionDetector : Detector(), SourceCodeScanner {
+    override fun getApplicableUastTypes() = listOf(UMethod::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler {
+      return object : UElementHandler() {
+        override fun visitMethod(node: UMethod) {
+          if (KotlinVersion.CURRENT == EXPECTED_VERSION) {
+            // Report something anyway to ensure our lint was correctly picked up at least
+            context.report(ISSUE, node, context.getLocation(node), "Kotlin version was expected")
+          } else {
+            context.report(
+              ISSUE,
+              node,
+              context.getLocation(node),
+              "Kotlin version was ${KotlinVersion.CURRENT}, expected $EXPECTED_VERSION"
+            )
+          }
+        }
+      }
+    }
+
+    companion object {
+      private val EXPECTED_VERSION = KotlinVersion(1, 9, 20)
+      val ISSUE =
+        Issue.create(
+          "KotlinVersion",
+          "Kotlin version",
+          "Kotlin version",
+          sourceImplementation<KotlinVersionDetector>(),
+          severity = Severity.ERROR,
+        )
+    }
   }
 }

--- a/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
@@ -34,7 +34,6 @@ class LintKotlinVersionCheckTest : BaseSlackLintTest() {
               println("Hello, world!")
             }
           """
-            .trimIndent()
         )
       )
       .run()

--- a/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
@@ -1,0 +1,15 @@
+package slack.lint
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Lint chases Kotlin versions differently than what we declare our build with. This test is just
+ * here to catch those for our own awareness and should be updated whenever lint updates its own.
+ */
+class LintKotlinVersionCheckTest {
+  @Test
+  fun check() {
+    assertThat(KotlinVersion.CURRENT).isEqualTo(KotlinVersion(1, 9, 20))
+  }
+}

--- a/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package slack.lint
 
 import com.google.common.truth.Truth.assertThat


### PR DESCRIPTION
Lint chases kotlin versions surprisingly quick, including RCs. This adds a test so we can keep track of this and not be surprised. For example, starting in 31.3.0-alpha06 they moved to kotlin 1.9.20 betas