### PR TITLE
Update kotlin language version to match latest in lint + clean up

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,8 +69,9 @@ val lintJvmTargetString: String = libs.versions.lintJvmTarget.get()
 val runtimeJvmTargetString: String = libs.versions.runtimeJvmTarget.get()
 
 subprojects {
+  val isChecksProject = path == ":slack-lint-checks"
   val jvmTargetString =
-    if (path == ":slack-lint-checks") {
+    if (isChecksProject) {
       lintJvmTargetString
     } else {
       runtimeJvmTargetString
@@ -88,9 +89,11 @@ subprojects {
     tasks.withType<KotlinCompile>().configureEach {
       compilerOptions {
         jvmTarget.set(JvmTarget.fromTarget(jvmTargetString))
-        // TODO re-enable if lint ever targets latest kotlin versions
-        //  allWarningsAsErrors.set(true)
-        //  freeCompilerArgs.add("-progressive")
+        // TODO re-enable on checks if lint ever targets latest kotlin versions
+        if (isChecksProject) {
+          allWarningsAsErrors.set(true)
+          progressiveMode.set(true)
+        }
       }
     }
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ runtimeJvmTarget = "11"
 lint = "31.3.0-alpha17"
 
 [plugins]
+buildConfig = { id = "com.github.gmazzo.buildconfig", version = "4.2.0" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.23.4" }
 dokka = { id = "org.jetbrains.dokka", version = "1.9.10" }
 lint = { id = "com.android.lint", version = "8.2.0" }

--- a/slack-lint-checks/build.gradle.kts
+++ b/slack-lint-checks/build.gradle.kts
@@ -11,6 +11,18 @@ plugins {
   alias(libs.plugins.ksp)
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.mavenShadow)
+  alias(libs.plugins.buildConfig)
+}
+
+val lintKotlinVersion = KotlinVersion(1, 9, 21)
+buildConfig {
+  packageName("slack.lint")
+  useKotlinOutput {
+    internalVisibility = true
+  }
+  sourceSets.getByName("test") {
+    buildConfigField("kotlin.KotlinVersion", "LINT_KOTLIN_VERSION", "KotlinVersion(${lintKotlinVersion.major}, ${lintKotlinVersion.minor}, ${lintKotlinVersion.patch})")
+  }
 }
 
 lint {
@@ -42,13 +54,14 @@ dependencies {
   testImplementation(libs.eithernet)
 }
 
+val kgpKotlinVersion = KotlinVersion.fromVersion(lintKotlinVersion.toString().substringBeforeLast('.'))
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
     // Lint forces Kotlin (regardless of what version the project uses), so this
     // forces a matching language level for now. Similar to `targetCompatibility` for Java.
     // This should match the value in LintKotlinVersionCheckTest.kt
-    apiVersion.set(KotlinVersion.KOTLIN_1_9)
-    languageVersion.set(KotlinVersion.KOTLIN_1_9)
+    apiVersion.set(kgpKotlinVersion)
+    languageVersion.set(kgpKotlinVersion)
   }
 }
 

--- a/slack-lint-checks/build.gradle.kts
+++ b/slack-lint-checks/build.gradle.kts
@@ -15,13 +15,16 @@ plugins {
 }
 
 val lintKotlinVersion = KotlinVersion(1, 9, 21)
+
 buildConfig {
   packageName("slack.lint")
-  useKotlinOutput {
-    internalVisibility = true
-  }
+  useKotlinOutput { internalVisibility = true }
   sourceSets.getByName("test") {
-    buildConfigField("kotlin.KotlinVersion", "LINT_KOTLIN_VERSION", "KotlinVersion(${lintKotlinVersion.major}, ${lintKotlinVersion.minor}, ${lintKotlinVersion.patch})")
+    buildConfigField(
+      "kotlin.KotlinVersion",
+      "LINT_KOTLIN_VERSION",
+      "KotlinVersion(${lintKotlinVersion.major}, ${lintKotlinVersion.minor}, ${lintKotlinVersion.patch})"
+    )
   }
 }
 
@@ -54,7 +57,9 @@ dependencies {
   testImplementation(libs.eithernet)
 }
 
-val kgpKotlinVersion = KotlinVersion.fromVersion(lintKotlinVersion.toString().substringBeforeLast('.'))
+val kgpKotlinVersion =
+  KotlinVersion.fromVersion(lintKotlinVersion.toString().substringBeforeLast('.'))
+
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
     // Lint forces Kotlin (regardless of what version the project uses), so this

--- a/slack-lint-checks/build.gradle.kts
+++ b/slack-lint-checks/build.gradle.kts
@@ -46,8 +46,9 @@ tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
     // Lint forces Kotlin (regardless of what version the project uses), so this
     // forces a matching language level for now. Similar to `targetCompatibility` for Java.
-    apiVersion.set(KotlinVersion.KOTLIN_1_8)
-    languageVersion.set(KotlinVersion.KOTLIN_1_8)
+    // This should match the value in LintKotlinVersionCheckTest.kt
+    apiVersion.set(KotlinVersion.KOTLIN_1_9)
+    languageVersion.set(KotlinVersion.KOTLIN_1_9)
   }
 }
 

--- a/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/LintKotlinVersionCheckTest.kt
@@ -76,7 +76,7 @@ class LintKotlinVersionCheckTest : BaseSlackLintTest() {
     }
 
     companion object {
-      private val EXPECTED_VERSION = KotlinVersion(1, 9, 21)
+      private val EXPECTED_VERSION = TestBuildConfig.LINT_KOTLIN_VERSION
       val ISSUE =
         Issue.create(
           "KotlinVersion",


### PR DESCRIPTION
This is some upkeep work to update our lint kotlin target and simplify the future maintenance of it by aligning the lint version used everywhere