### PR TITLE
Expand Mock option explanation for use with multiple issues.

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/mocking/MockDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/mocking/MockDetector.kt
@@ -58,7 +58,7 @@ constructor(
         "mock-annotations",
         "A comma-separated list of mock annotations.",
         "org.mockito.Mock,org.mockito.Spy",
-        "This property should define comma-separated list of mock annotation class names (FQCN).",
+        "This property should define comma-separated list of mock annotation class names (FQCN). Set this for all issues using this option.",
       )
 
     internal val MOCK_FACTORIES =
@@ -66,7 +66,7 @@ constructor(
         "mock-factories",
         "A comma-separated list of mock factories (org.mockito.Mockito#methodName).",
         "org.mockito.Mockito#mock,org.mockito.Mockito#spy,slack.test.mockito.MockitoHelpers#mock,slack.test.mockito.MockitoHelpersKt#mock",
-        "A comma-separated list of mock factories (org.mockito.Mockito#methodName).",
+        "A comma-separated list of mock factories (org.mockito.Mockito#methodName). Set this for all issues using this option.",
       )
 
     internal val MOCK_REPORT =
@@ -74,7 +74,7 @@ constructor(
         "mock-report",
         "If enabled, writes a mock report to <project-dir>/$MOCK_REPORT_PATH.",
         "none",
-        "If enabled, writes a mock report to <project-dir>/$MOCK_REPORT_PATH. The format of the file is a csv of (type,isError) of mocked classes.",
+        "If enabled, writes a mock report to <project-dir>/$MOCK_REPORT_PATH. The format of the file is a csv of (type,isError) of mocked classes. Set this for all issues using this option.",
       )
 
     private val TYPE_CHECKERS =


### PR DESCRIPTION
###  Summary

I spend quite some time figuring out why configuring the various "Do Not Mock" lint checks were not working with [Mockito Kotlin](https://github.com/mockito/mockito-kotlin), even after configuring the `mock-factories` through `lint.xml`. I configured it like this:

```xml
    <issue id="DoNotMock">
        <option name="mock-factories" value="org.mockito.kotlin.MockingKt#mock,org.mockito.kotlin.SpyingKt#spy" />
    </issue>

    <issue id="DoNotMockDataClass">
        <option name="mock-factories" value="org.mockito.kotlin.MockingKt#mock,org.mockito.kotlin.SpyingKt#spy" />
    </issue>

    <issue id="DoNotMockObjectClass">
        <option name="mock-factories" value="org.mockito.kotlin.MockingKt#mock,org.mockito.kotlin.SpyingKt#spy" />
    </issue>
```

However, it did not work until I added the option for `DoNotMockRecordClass`

```xml
    <issue id="DoNotMockRecordClass">
        <option name="mock-factories" value="org.mockito.kotlin.MockingKt#mock,org.mockito.kotlin.SpyingKt#spy" />
    </issue>
```

It turns out that Lint overrides the option to the value used in the latest registered issue (tested in AGP `8.3.0` and `8.4.0-beta02` and their lint checks). So setting it up just for `DoNotMockRecordClass` works, as well as setting it up for all issues with the option.

This PR adds this to the explanation of the option. I understand this is not an issue with this project and it might not be relevant for Slack since it's already set up correctly, so feel free to decline this. But I figured I'd put up a PR in case folks running into the same problem.

Thanks for the work on this project 🙏.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
