### PR TITLE
Load external denylist entries via ServiceLoader

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/denylistedapis/DenyListedEntryLoader.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/denylistedapis/DenyListedEntryLoader.kt
@@ -1,0 +1,5 @@
+package slack.lint.denylistedapis
+
+interface DenyListedEntryLoader {
+  val entries: Set<DenyListedEntry>
+}

--- a/slack-lint-checks/src/test/java/slack/lint/denylistedapis/DenyListedApiDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/denylistedapis/DenyListedApiDetectorTest.kt
@@ -700,6 +700,38 @@ class DenyListedApiDetectorTest : BaseSlackLintTest() {
       )
   }
 
+  @Test
+  fun externalDenylistEntries() {
+    lint()
+      .files(
+        EXTERNAL_ENTRY_TESTCLASS_STUB,
+        kotlin(
+          """
+          package foo
+
+          import slack.lint.TestClass
+
+          class SomeClass {
+            fun test() {
+              TestClass.run()
+            }
+          }
+          """
+        )
+          .indented()
+      )
+      .run()
+      .expect(
+        """
+        src/foo/SomeClass.kt:7: Error: TestClass.run() is disallowed in tests via external denylist entry. [DenyListedApi]
+            TestClass.run()
+                      ~~~
+        1 errors, 0 warnings
+        """
+          .trimIndent()
+      )
+  }
+
   companion object {
     private val FLOWABLE_STUB =
       java(
@@ -1026,5 +1058,16 @@ class DenyListedApiDetectorTest : BaseSlackLintTest() {
       """
         )
         .indented()
+
+    private val EXTERNAL_ENTRY_TESTCLASS_STUB =
+      kotlin(
+        """
+          package slack.lint
+
+          object TestClass {
+            fun run() {}
+          }
+        """.trimIndent()
+      )
   }
 }

--- a/slack-lint-checks/src/test/java/slack/lint/denylistedapis/TestEntriesLoader.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/denylistedapis/TestEntriesLoader.kt
@@ -1,0 +1,12 @@
+package slack.lint.denylistedapis
+
+internal class TestEntriesLoader: DenyListedEntryLoader {
+  override val entries: Set<DenyListedEntry> =
+    setOf(
+      DenyListedEntry(
+        className = "slack.lint.TestClass",
+        functionName = "run",
+        errorMessage = "TestClass.run() is disallowed in tests via external denylist entry."
+      )
+    )
+}

--- a/slack-lint-checks/src/test/resources/META-INF/services/slack.lint.denylistedapis.DenyListedEntryLoader
+++ b/slack-lint-checks/src/test/resources/META-INF/services/slack.lint.denylistedapis.DenyListedEntryLoader
@@ -1,0 +1,1 @@
+slack.lint.denylistedapis.TestEntriesLoader


### PR DESCRIPTION
###  Summary

Allow consumers to supply their own `DenyListedEntry`s via a `ServiceLoader` interface. Fixes #241. 

Open to suggestions on any of the names, or if there's a preferred use of `ServiceLoader` (it's new to me!)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
