### PR TITLE
Allow unit return type for suspend functions

### DIFF
--- a/slack-lint-annotations/src/main/kotlin/slack/lint/annotations/AllowUnitResponse.kt
+++ b/slack-lint-annotations/src/main/kotlin/slack/lint/annotations/AllowUnitResponse.kt
@@ -1,0 +1,11 @@
+package slack.lint.annotations
+
+/**
+ * Annotation to allow suspend Retrofit functions to return Unit.
+ * 
+ * When applied to a suspend Retrofit function, this annotation permits the function 
+ * to have a return type of Unit, which otherwise will be flagged as an issue.
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class AllowUnitResponse

--- a/slack-lint-checks/src/main/java/slack/lint/retrofit/RetrofitUsageDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/retrofit/RetrofitUsageDetector.kt
@@ -39,11 +39,12 @@ class RetrofitUsageDetector : Detector(), SourceCodeScanner {
           HTTP_ANNOTATIONS.firstNotNullOfOrNull { node.findAnnotation(it) } ?: return
 
         val returnType = node.safeReturnType(context)
-        if (
-          returnType == null ||
-            returnType == PsiTypes.voidType() ||
-            returnType.canonicalText == "kotlin.Unit"
-        ) {
+        val isSuspend = context.evaluator.isSuspend(node)
+
+        val hasInvalidUnitReturnTypeUsage = returnType == null ||
+                                   (!isSuspend && (returnType == PsiTypes.voidType() || returnType.canonicalText == "kotlin.Unit"))
+
+        if (hasInvalidUnitReturnTypeUsage) {
           node.report(
             "Retrofit endpoints should return something other than Unit/void.",
             context.getNameLocation(node),

--- a/slack-lint-checks/src/main/java/slack/lint/retrofit/RetrofitUsageDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/retrofit/RetrofitUsageDetector.kt
@@ -40,9 +40,12 @@ class RetrofitUsageDetector : Detector(), SourceCodeScanner {
 
         val returnType = node.safeReturnType(context)
         val isSuspend = context.evaluator.isSuspend(node)
-
+        val hasAllowUnitResponseAnnotation = node.findAnnotation("slack.lint.annotations.AllowUnitResponse") != null
+        val isVoidOrUnitReturnType = returnType == PsiTypes.voidType() ||
+                                     returnType?.canonicalText == "kotlin.Unit"
+        val shouldDisallowUnitReturnType = !isSuspend || !hasAllowUnitResponseAnnotation
         val hasInvalidUnitReturnTypeUsage = returnType == null ||
-                                   (!isSuspend && (returnType == PsiTypes.voidType() || returnType.canonicalText == "kotlin.Unit"))
+                                            (isVoidOrUnitReturnType && shouldDisallowUnitReturnType)
 
         if (hasInvalidUnitReturnTypeUsage) {
           node.report(

--- a/slack-lint-checks/src/test/java/slack/lint/retrofit/RetrofitUsageDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/retrofit/RetrofitUsageDetectorTest.kt
@@ -22,7 +22,7 @@ class RetrofitUsageDetectorTest : BaseSlackLintTest() {
          * to have a return type of Unit, which otherwise will be flagged as an issue.
          */
         @Target(AnnotationTarget.FUNCTION)
-        @Retention(AnnotationRetention.RUNTIME)
+        @Retention(AnnotationRetention.BINARY)
         annotation class AllowUnitResponse
       """
         )

--- a/slack-lint-checks/src/test/java/slack/lint/retrofit/RetrofitUsageDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/retrofit/RetrofitUsageDetectorTest.kt
@@ -16,7 +16,10 @@ class RetrofitUsageDetectorTest : BaseSlackLintTest() {
         package slack.lint.annotations
 
         /**
-         * Suspend retrofit call functions annotated with this can return Unit.
+         * Annotation to allow suspend Retrofit functions to return Unit.
+         *
+         * When applied to a suspend Retrofit function, this annotation permits the function
+         * to have a return type of Unit, which otherwise will be flagged as an issue.
          */
         @Target(AnnotationTarget.FUNCTION)
         @Retention(AnnotationRetention.RUNTIME)

--- a/slack-lint-checks/src/test/java/slack/lint/retrofit/RetrofitUsageDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/retrofit/RetrofitUsageDetectorTest.kt
@@ -158,13 +158,10 @@ class RetrofitUsageDetectorTest : BaseSlackLintTest() {
         src/test/Example.kt:7: Error: Retrofit endpoints should return something other than Unit/void. [RetrofitUsage]
           fun unitMethod()
               ~~~~~~~~~~
-        src/test/Example.kt:10: Error: Retrofit endpoints should return something other than Unit/void. [RetrofitUsage]
-          suspend fun suspendUnitMethod()
-                      ~~~~~~~~~~~~~~~~~
         src/test/Example.kt:13: Error: Retrofit endpoints should return something other than Unit/void. [RetrofitUsage]
           fun unitMethodExplicit(): Unit
               ~~~~~~~~~~~~~~~~~~
-        3 errors, 0 warnings
+        2 errors, 0 warnings
         """
           .trimIndent()
       )


### PR DESCRIPTION
###  Summary

This pr aims to fix the lint rule for retrofit usage. Solves [this issue](https://github.com/slackhq/slack-lints/issues/239#issuecomment-2214768419)

For suspend functions it's a valid case to return Unit.

### Requirements (place an `x` in each `[ ]`)
Unfortunately the contributing guidelines and Contributor license agreement links are not working.

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
