### PR TITLE
Switch to stable kotlin metadata + update shadow plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ lint = { id = "com.android.lint", version = "8.7.0-alpha07" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version = "2.0.20-1.0.24" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.29.0" }
-mavenShadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
+shadow = { id = "com.gradleup.shadow", version = "8.3.0" }
 spotless = { id = "com.diffplug.spotless", version = "6.25.0" }
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ spotless = { id = "com.diffplug.spotless", version = "6.25.0" }
 autoService-annotations = "com.google.auto.service:auto-service-annotations:1.1.1"
 autoService-ksp = "dev.zacsweers.autoservice:auto-service-ksp:1.2.0"
 junit = "junit:junit:4.13.2"
-kotlin-metadata = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version = "0.9.0" }
+kotlin-metadata = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlin" }
 ktfmt = { module = "com.facebook:ktfmt", version.ref = "ktfmt" }
 eithernet = "com.slack.eithernet:eithernet:1.9.0"
 retrofit = "com.squareup.retrofit2:retrofit:2.11.0"

--- a/slack-lint-checks/build.gradle.kts
+++ b/slack-lint-checks/build.gradle.kts
@@ -57,7 +57,9 @@ dependencies {
   shade(libs.kotlin.metadata) { exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib") }
 
   // Dupe the dep because the shaded version is compileOnly in the eyes of the gradle configurations
-  testImplementation(libs.kotlin.metadata) { exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib") }
+  testImplementation(libs.kotlin.metadata) {
+    exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib")
+  }
   testImplementation(libs.bundles.lintTest)
   testImplementation(libs.junit)
 

--- a/slack-lint-checks/build.gradle.kts
+++ b/slack-lint-checks/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
   alias(libs.plugins.buildConfig)
 }
 
-val lintKotlinVersion = KotlinVersion(1, 9, 21)
+val lintKotlinVersion = KotlinVersion(1, 9, 20)
 
 buildConfig {
   packageName("slack.lint")
@@ -57,7 +57,7 @@ dependencies {
   shade(libs.kotlin.metadata) { exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib") }
 
   // Dupe the dep because the shaded version is compileOnly in the eyes of the gradle configurations
-  testImplementation(libs.kotlin.metadata)
+  testImplementation(libs.kotlin.metadata) { exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib") }
   testImplementation(libs.bundles.lintTest)
   testImplementation(libs.junit)
 

--- a/slack-lint-checks/build.gradle.kts
+++ b/slack-lint-checks/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
   alias(libs.plugins.lint)
   alias(libs.plugins.ksp)
   alias(libs.plugins.mavenPublish)
-  alias(libs.plugins.mavenShadow)
+  alias(libs.plugins.shadow)
   alias(libs.plugins.buildConfig)
 }
 

--- a/slack-lint-checks/src/main/java/slack/lint/util/MetadataJavaEvaluator.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/util/MetadataJavaEvaluator.kt
@@ -18,16 +18,16 @@ import com.intellij.psi.PsiType
 import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.jvm.optionals.getOrNull
-import kotlinx.metadata.ClassKind
-import kotlinx.metadata.KmClass
-import kotlinx.metadata.Modality
-import kotlinx.metadata.isData
-import kotlinx.metadata.isValue
-import kotlinx.metadata.jvm.JvmMetadataVersion
-import kotlinx.metadata.jvm.KotlinClassMetadata
-import kotlinx.metadata.jvm.Metadata as MetadataWithNullableArgs
-import kotlinx.metadata.kind
-import kotlinx.metadata.modality
+import kotlin.metadata.ClassKind
+import kotlin.metadata.KmClass
+import kotlin.metadata.Modality
+import kotlin.metadata.isData
+import kotlin.metadata.isValue
+import kotlin.metadata.jvm.JvmMetadataVersion
+import kotlin.metadata.jvm.KotlinClassMetadata
+import kotlin.metadata.jvm.Metadata as MetadataWithNullableArgs
+import kotlin.metadata.kind
+import kotlin.metadata.modality
 import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtObjectDeclaration

--- a/slack-lint-checks/src/main/java/slack/lint/util/Names.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/util/Names.kt
@@ -15,7 +15,7 @@
  */
 package slack.lint.util
 
-import kotlinx.metadata.ClassName
+import kotlin.metadata.ClassName
 
 /**
  * Represents a qualified package


### PR DESCRIPTION
kotlin-metadata is now stable in K2, but we still have to shade it for a couple reasons
- lint still targets kotlin 1.9
- lint also only includes the stdlib on the classpath, not metadata

Also updates the shadow plugin to its new coordinates: https://github.com/GradleUp/shadow/releases/tag/8.3.0