### PR TITLE
Update rx-coroutines interop lint message

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/denylistedapis/DenyListedApiDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/denylistedapis/DenyListedApiDetector.kt
@@ -371,7 +371,7 @@ internal class DenyListedApiDetector : Detector(), SourceCodeScanner, XmlScanner
           className = "kotlinx.coroutines.rx3.RxCompletableKt",
           functionName = "rxCompletable",
           errorMessage =
-            "rxCompletable defaults to Dispatchers.Default, which will silently introduce multithreading. Provide an explicit dispatcher. Dispatchers.Unconfined is usually the best choice, as it behaves in an rx-y way.",
+            "rxCompletable defaults to Dispatchers.Default. Provide an explicit dispatcher which can be replaced with a test dispatcher to make your tests more deterministic.",
           parameters =
             listOf(
               "kotlin.coroutines.CoroutineContext",
@@ -383,7 +383,7 @@ internal class DenyListedApiDetector : Detector(), SourceCodeScanner, XmlScanner
           className = "kotlinx.coroutines.rx3.RxMaybeKt",
           functionName = "rxMaybe",
           errorMessage =
-            "rxMaybe defaults to Dispatchers.Default, which will silently introduce multithreading. Provide an explicit dispatcher. Dispatchers.Unconfined is usually the best choice, as it behaves in an rx-y way.",
+            "rxMaybe defaults to Dispatchers.Default. Provide an explicit dispatcher which can be replaced with a test dispatcher to make your tests more deterministic.",
           parameters =
             listOf(
               "kotlin.coroutines.CoroutineContext",
@@ -395,7 +395,7 @@ internal class DenyListedApiDetector : Detector(), SourceCodeScanner, XmlScanner
           className = "kotlinx.coroutines.rx3.RxSingleKt",
           functionName = "rxSingle",
           errorMessage =
-            "rxSingle defaults to Dispatchers.Default, which will silently introduce multithreading. Provide an explicit dispatcher. Dispatchers.Unconfined is usually the best choice, as it behaves in an rx-y way.",
+            "rxSingle defaults to Dispatchers.Default. Provide an explicit dispatcher which can be replaced with a test dispatcher to make your tests more deterministic.",
           parameters =
             listOf(
               "kotlin.coroutines.CoroutineContext",
@@ -407,7 +407,7 @@ internal class DenyListedApiDetector : Detector(), SourceCodeScanner, XmlScanner
           className = "kotlinx.coroutines.rx3.RxObservableKt",
           functionName = "rxObservable",
           errorMessage =
-            "rxObservable defaults to Dispatchers.Default, which will silently introduce multithreading. Provide an explicit dispatcher. Dispatchers.Unconfined is usually the best choice, as it behaves in an rx-y way.",
+            "rxObservable defaults to Dispatchers.Default. Provide an explicit dispatcher which can be replaced with a test dispatcher to make your tests more deterministic.",
           parameters =
             listOf(
               "kotlin.coroutines.CoroutineContext",

--- a/slack-lint-checks/src/test/java/slack/lint/denylistedapis/DenyListedApiDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/denylistedapis/DenyListedApiDetectorTest.kt
@@ -446,7 +446,7 @@ class DenyListedApiDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/foo/SomeClass.kt:6: Error: rxCompletable defaults to Dispatchers.Default, which will silently introduce multithreading. Provide an explicit dispatcher. Dispatchers.Unconfined is usually the best choice, as it behaves in an rx-y way. [DenyListedApi]
+        src/foo/SomeClass.kt:6: Error: rxCompletable defaults to Dispatchers.Default. Provide an explicit dispatcher which can be replaced with a test dispatcher to make your tests more deterministic. [DenyListedApi]
           val now = rxCompletable {}
                     ~~~~~~~~~~~~~
         1 errors, 0 warnings
@@ -478,7 +478,7 @@ class DenyListedApiDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/foo/SomeClass.kt:6: Error: rxSingle defaults to Dispatchers.Default, which will silently introduce multithreading. Provide an explicit dispatcher. Dispatchers.Unconfined is usually the best choice, as it behaves in an rx-y way. [DenyListedApi]
+        src/foo/SomeClass.kt:6: Error: rxSingle defaults to Dispatchers.Default. Provide an explicit dispatcher which can be replaced with a test dispatcher to make your tests more deterministic. [DenyListedApi]
           val now = rxSingle { "a" }
                     ~~~~~~~~
         1 errors, 0 warnings
@@ -510,7 +510,7 @@ class DenyListedApiDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/foo/SomeClass.kt:6: Error: rxMaybe defaults to Dispatchers.Default, which will silently introduce multithreading. Provide an explicit dispatcher. Dispatchers.Unconfined is usually the best choice, as it behaves in an rx-y way. [DenyListedApi]
+        src/foo/SomeClass.kt:6: Error: rxMaybe defaults to Dispatchers.Default. Provide an explicit dispatcher which can be replaced with a test dispatcher to make your tests more deterministic. [DenyListedApi]
           val now = rxMaybe { "a" }
                     ~~~~~~~
         1 errors, 0 warnings
@@ -544,7 +544,7 @@ class DenyListedApiDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/foo/SomeClass.kt:6: Error: rxObservable defaults to Dispatchers.Default, which will silently introduce multithreading. Provide an explicit dispatcher. Dispatchers.Unconfined is usually the best choice, as it behaves in an rx-y way. [DenyListedApi]
+        src/foo/SomeClass.kt:6: Error: rxObservable defaults to Dispatchers.Default. Provide an explicit dispatcher which can be replaced with a test dispatcher to make your tests more deterministic. [DenyListedApi]
           val now = rxObservable { send("a") }
                     ~~~~~~~~~~~~
         1 errors, 0 warnings


### PR DESCRIPTION
###  Summary

Update rx-coroutines interop lint message to:
> rxSingle defaults to Dispatchers.Default. Provide an explicit dispatcher which can be replaced with a test dispatcher to make your tests more deterministic.

As `Dispatchers.Unconfined` may lead to unintended threading and should only be used deliberately, remove it as a recommendation from the lint message.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
