### PR TITLE
Add @Multipart/@Part Retrofit lint updates

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/retrofit/RetrofitUsageDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/retrofit/RetrofitUsageDetector.kt
@@ -55,13 +55,13 @@ class RetrofitUsageDetector : Detector(), SourceCodeScanner {
         val annotationsByFqcn = node.uAnnotations.associateBy { it.qualifiedName }
 
         val isFormUrlEncoded = FQCN_FORM_ENCODED in annotationsByFqcn
-        val isMultipart = FQCN_MULTIPART in annotationsByFqcn
 
         if (isFormUrlEncoded && !isBodyMethod) {
           node.report("@FormUrlEncoded requires @PUT, @POST, or @PATCH.")
           return
         }
 
+        val isMultipart = FQCN_MULTIPART in annotationsByFqcn
         if (isMultipart && !isBodyMethod) {
           node.report("@Multipart requires @PUT, @POST, or @PATCH.")
           return

--- a/slack-lint-checks/src/main/java/slack/lint/retrofit/RetrofitUsageDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/retrofit/RetrofitUsageDetector.kt
@@ -55,9 +55,15 @@ class RetrofitUsageDetector : Detector(), SourceCodeScanner {
         val annotationsByFqcn = node.uAnnotations.associateBy { it.qualifiedName }
 
         val isFormUrlEncoded = FQCN_FORM_ENCODED in annotationsByFqcn
+        val isMultipart = FQCN_MULTIPART in annotationsByFqcn
 
         if (isFormUrlEncoded && !isBodyMethod) {
           node.report("@FormUrlEncoded requires @PUT, @POST, or @PATCH.")
+          return
+        }
+
+        if (isMultipart && !isBodyMethod) {
+          node.report("@Multipart requires @PUT, @POST, or @PATCH.")
           return
         }
 
@@ -67,6 +73,7 @@ class RetrofitUsageDetector : Detector(), SourceCodeScanner {
 
         var hasBodyParam = false
         var hasFieldParams = false
+        var hasPartParams = false
         var hasUrlParam = false
 
         for (parameter in node.uastParameters) {
@@ -101,6 +108,12 @@ class RetrofitUsageDetector : Detector(), SourceCodeScanner {
             } else {
               hasUrlParam = true
             }
+          } else if (parameter.hasAnnotation(FQCN_PART)) {
+            if (!isBodyMethod) {
+              httpAnnotation.report("@Part param requires @PUT, @POST, or @PATCH.")
+            } else {
+              hasPartParams = true
+            }
           }
         }
 
@@ -112,7 +125,13 @@ class RetrofitUsageDetector : Detector(), SourceCodeScanner {
               quickFixData = LintFix.create().removeNode(context, annotation.sourcePsiElement!!),
             )
           }
-        } else if (isBodyMethod && !hasBodyParam && !hasFieldParams) {
+        } else if (isMultipart) {
+          if (hasBodyParam || hasFieldParams) {
+            httpAnnotation.report("@Multipart methods should only contain @Part parameters.")
+          } else if (!hasPartParams) {
+            httpAnnotation.report("@Multipart methods should contain at least one @Part parameter.")
+          }
+        } else if (isBodyMethod && !hasBodyParam && !hasFieldParams && !hasPartParams) {
           httpAnnotation.report("This annotation requires an `@Body` parameter.")
         }
         if (!hasPath && !hasUrlParam) {
@@ -144,7 +163,9 @@ class RetrofitUsageDetector : Detector(), SourceCodeScanner {
     private val HTTP_BODY_ANNOTATIONS =
       setOf("retrofit2.http.PATCH", "retrofit2.http.POST", "retrofit2.http.PUT")
     private const val FQCN_FORM_ENCODED = "retrofit2.http.FormUrlEncoded"
+    private const val FQCN_MULTIPART = "retrofit2.http.Multipart"
     private const val FQCN_FIELD = "retrofit2.http.Field"
+    private const val FQCN_PART = "retrofit2.http.Part"
     private const val FQCN_FIELD_MAP = "retrofit2.http.FieldMap"
     private const val FQCN_BODY = "retrofit2.http.Body"
     private const val FQCN_URL = "retrofit2.http.Url"

--- a/slack-lint-checks/src/test/java/slack/lint/retrofit/RetrofitUsageDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/retrofit/RetrofitUsageDetectorTest.kt
@@ -90,6 +90,8 @@ class RetrofitUsageDetectorTest : BaseSlackLintTest() {
 
             import retrofit2.http.Body
             import retrofit2.http.GET
+            import retrofit2.http.Multipart
+            import retrofit2.http.Part
             import retrofit2.http.POST
 
             interface Example {
@@ -104,6 +106,22 @@ class RetrofitUsageDetectorTest : BaseSlackLintTest() {
 
               @POST("/")
               fun correct(@Body input: String): String
+
+              @Multipart
+              @POST("/")
+              fun multipartCorrect(@Part input: String): String
+              
+              @Multipart
+              @GET("/")
+              fun multipartBadMethod(@Part input: String): String
+              
+              @Multipart
+              @POST("/")
+              fun multipartBadParameterType(@Body input: String): String
+              
+              @Multipart
+              @POST("/")
+              fun multipartMissingPartParameter(): String
             }
           """
           )
@@ -112,17 +130,26 @@ class RetrofitUsageDetectorTest : BaseSlackLintTest() {
       .run()
       .expect(
         """
-        src/test/Example.kt:8: Error: @Body param requires @PUT, @POST, or @PATCH. [RetrofitUsage]
-          @GET("/")
-          ~~~~~~~~~
-        src/test/Example.kt:11: Error: This annotation requires an @Body parameter. [RetrofitUsage]
-          @POST("/")
-          ~~~~~~~~~~
-        src/test/Example.kt:15: Error: Duplicate @Body param!. [RetrofitUsage]
-          fun doubleBody(@Body input: String, @Body input2: String): String
-                                              ~~~~~~~~~~~~~~~~~~~~
-        3 errors, 0 warnings
-        """
+          src/test/Example.kt:10: Error: @Body param requires @PUT, @POST, or @PATCH. [RetrofitUsage]
+            @GET("/")
+            ~~~~~~~~~
+          src/test/Example.kt:13: Error: This annotation requires an @Body parameter. [RetrofitUsage]
+            @POST("/")
+            ~~~~~~~~~~
+          src/test/Example.kt:17: Error: Duplicate @Body param!. [RetrofitUsage]
+            fun doubleBody(@Body input: String, @Body input2: String): String
+                                                ~~~~~~~~~~~~~~~~~~~~
+          src/test/Example.kt:28: Error: @Multipart requires @PUT, @POST, or @PATCH. [RetrofitUsage]
+            fun multipartBadMethod(@Part input: String): String
+                ~~~~~~~~~~~~~~~~~~
+          src/test/Example.kt:31: Error: @Multipart methods should only contain @Part parameters. [RetrofitUsage]
+            @POST("/")
+            ~~~~~~~~~~
+          src/test/Example.kt:35: Error: @Multipart methods should contain at least one @Part parameter. [RetrofitUsage]
+            @POST("/")
+            ~~~~~~~~~~
+          6 errors, 0 warnings
+          """
           .trimIndent()
       )
   }

--- a/slack-lint-checks/src/test/java/slack/lint/retrofit/RetrofitUsageDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/retrofit/RetrofitUsageDetectorTest.kt
@@ -110,15 +110,15 @@ class RetrofitUsageDetectorTest : BaseSlackLintTest() {
               @Multipart
               @POST("/")
               fun multipartCorrect(@Part input: String): String
-              
+
               @Multipart
               @GET("/")
               fun multipartBadMethod(@Part input: String): String
-              
+
               @Multipart
               @POST("/")
               fun multipartBadParameterType(@Body input: String): String
-              
+
               @Multipart
               @POST("/")
               fun multipartMissingPartParameter(): String


### PR DESCRIPTION
###  Summary

This PR updates the `RetrofitUsageDetector` to include support for `@Multipart` annotated methods and `@Part` annotated parameters per [Retrofit doc](https://square.github.io/retrofit/#:~:text=FORM%20ENCODED%20AND%20MULTIPART). Added test cases for new lints and success path.

### Requirements (place an `x` in each `[ ]`)

* [x ] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x ] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
