### PR TITLE
Don't require ExceptionMessage lint in tests

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/ExceptionMessageDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/ExceptionMessageDetector.kt
@@ -76,9 +76,8 @@ class ExceptionMessageDetector : Detector(), SourceCodeScanner {
         category = Category.CORRECTNESS,
         priority = 3,
         severity = Severity.ERROR,
-        implementation = sourceImplementation<ExceptionMessageDetector>(
-          shouldRunOnTestSources = false
-        ),
+        implementation =
+          sourceImplementation<ExceptionMessageDetector>(shouldRunOnTestSources = false),
       )
   }
 }

--- a/slack-lint-checks/src/main/java/slack/lint/ExceptionMessageDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/ExceptionMessageDetector.kt
@@ -76,7 +76,9 @@ class ExceptionMessageDetector : Detector(), SourceCodeScanner {
         category = Category.CORRECTNESS,
         priority = 3,
         severity = Severity.ERROR,
-        implementation = sourceImplementation<ExceptionMessageDetector>(),
+        implementation = sourceImplementation<ExceptionMessageDetector>(
+          shouldRunOnTestSources = false
+        ),
       )
   }
 }


### PR DESCRIPTION
Tests are not prod-facing and here they can be helpful for their contracts
