### PR TITLE
Added mockito-kotlin mock/spy functions to mock factories

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/mocking/MockDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/mocking/MockDetector.kt
@@ -64,7 +64,7 @@ constructor(
       StringOption(
         "mock-factories",
         "A comma-separated list of mock factories (org.mockito.Mockito#methodName).",
-        "org.mockito.Mockito#mock,org.mockito.Mockito#spy,slack.test.mockito.MockitoHelpers#mock,slack.test.mockito.MockitoHelpersKt#mock",
+        "org.mockito.Mockito#mock,org.mockito.Mockito#spy,slack.test.mockito.MockitoHelpers#mock,slack.test.mockito.MockitoHelpersKt#mock,org.mockito.kotlin.MockingKt#mock,org.mockito.kotlin.SpyingKt#spy",
         "A comma-separated list of mock factories (org.mockito.Mockito#methodName). Set this for all issues using this option.",
       )
 


### PR DESCRIPTION
###  Summary

This PR adds mockito-kotlin support to mocking factories, properly identifying when a consumer uses the `org.mockito.kotlin.mock` function to mock things like data classes. 

- https://github.com/slackhq/slack-lints/issues/356

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [ ] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
