### PR TITLE
Create JsonInflaterMoshiCompatibilityDetector

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -73,8 +73,7 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
   private fun isJsonPrimitive(type: PsiType): Boolean {
     val isString =
       if (type is PsiClassType) {
-        type.resolve()?.qualifiedName == FQCN_JAVA_STRING ||
-          type.resolve()?.qualifiedName == FQCN_KOTLIN_STRING
+        type.resolve()?.qualifiedName == FQCN_JAVA_STRING
       } else {
         false
       }
@@ -169,7 +168,6 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
     // Fully qualified class names for relevant annotations and types
     private const val FQCN_JSON_INFLATER = "slack.commons.json.JsonInflater"
     private const val FQCN_JAVA_STRING = "java.lang.String"
-    private const val FQCN_KOTLIN_STRING = "kotlin.String"
     private const val FQCN_LIST = "java.util.List"
     private const val FQCN_SET = "java.util.Set"
     private const val FQCN_MAP = "java.util.Map"

--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -24,6 +24,8 @@ import slack.lint.util.sourceImplementation
 /**
  * A detector that checks if a type passed into the JsonInflater.inflate/deflate methods follows
  * Moshi's requirements for serialization/deserialization.
+ *
+ * `JsonInflater` is a JSON serialization indirection we have internally at Slack.
  */
 class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
 

--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -178,7 +178,7 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
     // Issue definitions
     private val ISSUE_JSON_INFLATER_WITH_MOSHI_INCOMPATIBLE_TYPE =
       Issue.create(
-        id = "JsonInflaterMoshiCompatibility:MoshiIncompatibleType",
+        id = "JsonInflaterMoshiIncompatibleType",
         "Using JsonInflater.inflate/deflate with a Moshi-incompatible type.",
         """
           Classes used with JsonInflater.inflate/deflate must be annotated with @JsonClass or @AdaptedBy to make it \

--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2025 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
 package slack.lint
 
 import com.android.tools.lint.client.api.UElementHandler
@@ -16,8 +18,8 @@ import org.jetbrains.uast.UCallExpression
 import slack.lint.util.sourceImplementation
 
 /**
- * A detector that checks if a type passed into the JsonInflater.inflate/deflate methods follows Moshi's requirements
- * for serialization/deserialization.
+ * A detector that checks if a type passed into the JsonInflater.inflate/deflate methods follows
+ * Moshi's requirements for serialization/deserialization.
  */
 class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
 
@@ -83,12 +85,17 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
     }
   }
 
-  private fun validateClassForMoshiCompatibility(context: JavaContext, node: UCallExpression, classToValidate: PsiClass) {
+  private fun validateClassForMoshiCompatibility(
+    context: JavaContext,
+    node: UCallExpression,
+    classToValidate: PsiClass,
+  ) {
     if (!isMoshiCompatible(classToValidate)) {
       context.report(
         issue = ISSUE_JSON_INFLATER_WITH_MOSHI_INCOMPATIBLE_TYPE,
         location = context.getLocation(node),
-        message = ISSUE_JSON_INFLATER_WITH_MOSHI_INCOMPATIBLE_TYPE.getBriefDescription(TextFormat.TEXT)
+        message =
+          ISSUE_JSON_INFLATER_WITH_MOSHI_INCOMPATIBLE_TYPE.getBriefDescription(TextFormat.TEXT),
       )
     }
   }
@@ -96,27 +103,29 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
   private fun isMoshiCompatible(psiClass: PsiClass): Boolean {
     if (!isInstantiable(psiClass)) return false
 
-    return hasPublicNoArgConstructor(psiClass) || hasJsonClassGenerateAdapter(psiClass) || hasAdaptedBy(psiClass)
+    return hasPublicNoArgConstructor(psiClass) ||
+      hasJsonClassGenerateAdapter(psiClass) ||
+      hasAdaptedBy(psiClass)
   }
 
   private fun isInstantiable(psiClass: PsiClass): Boolean {
-    return !psiClass.isInterface
-            && !psiClass.hasModifierProperty(PsiModifier.ABSTRACT)
-            && !psiClass.isEnum
-            && psiClass.hasModifierProperty(PsiModifier.PUBLIC)
+    return !psiClass.isInterface &&
+      !psiClass.hasModifierProperty(PsiModifier.ABSTRACT) &&
+      !psiClass.isEnum &&
+      psiClass.hasModifierProperty(PsiModifier.PUBLIC)
   }
 
   private fun hasPublicNoArgConstructor(psiClass: PsiClass): Boolean {
     return psiClass.constructors.any { constructor ->
       constructor.parameterList.parametersCount == 0 &&
-              constructor.hasModifierProperty(PsiModifier.PUBLIC)
+        constructor.hasModifierProperty(PsiModifier.PUBLIC)
     }
   }
 
   private fun hasJsonClassGenerateAdapter(psiClass: PsiClass): Boolean {
     return psiClass.annotations.any { annotation ->
       annotation.qualifiedName == FQCN_JSON_CLASS &&
-              annotation.findDeclaredAttributeValue("generateAdapter")?.text == "true"
+        annotation.findDeclaredAttributeValue("generateAdapter")?.text == "true"
     }
   }
 
@@ -129,7 +138,7 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
     private const val FQCN_JSON_INFLATER = "slack.commons.json.JsonInflater"
     private const val FQCN_JSON_CLASS = "com.squareup.moshi.JsonClass"
     private const val FQCN_ADAPTED_BY = "dev.zacsweers.moshix.adapters.AdaptedBy"
-    
+
     // Issue definitions
     private val ISSUE_JSON_INFLATER_WITH_MOSHI_INCOMPATIBLE_TYPE =
       Issue.create(
@@ -143,9 +152,9 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
         Category.CORRECTNESS,
         6,
         Severity.ERROR,
-        implementation = sourceImplementation<JsonInflaterMoshiCompatibilityDetector>()
+        implementation = sourceImplementation<JsonInflaterMoshiCompatibilityDetector>(),
       )
-    
+
     fun issues(): List<Issue> = listOf(ISSUE_JSON_INFLATER_WITH_MOSHI_INCOMPATIBLE_TYPE)
   }
 }

--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -142,7 +142,7 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
 
     if (!isInstantiable(psiClass)) return false
 
-    return hasPublicNoArgConstructor(psiClass) || psiClass.hasMoshiAnnotation()
+    return psiClass.hasMoshiAnnotation()
   }
 
   private fun isCollectionType(psiClass: PsiClass): Boolean {
@@ -155,13 +155,6 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
       !psiClass.hasModifierProperty(PsiModifier.ABSTRACT) &&
       !psiClass.isEnum &&
       psiClass.hasModifierProperty(PsiModifier.PUBLIC)
-  }
-
-  private fun hasPublicNoArgConstructor(psiClass: PsiClass): Boolean {
-    return psiClass.constructors.any { constructor ->
-      constructor.parameterList.parametersCount == 0 &&
-        constructor.hasModifierProperty(PsiModifier.PUBLIC)
-    }
   }
 
   companion object {

--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -183,8 +183,7 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
         """
           Classes used with JsonInflater.inflate/deflate must be annotated with @JsonClass or @AdaptedBy to make it \
           compatible with Moshi. Additionally, it cannot be an abstract class or an interface.
-        """
-          .trimIndent(),
+        """,
         Category.CORRECTNESS,
         6,
         Severity.ERROR,

--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -71,11 +71,13 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
   }
 
   private fun isJsonPrimitive(type: PsiType): Boolean {
-    val isString = if (type is PsiClassType) {
-      type.resolve()?.qualifiedName == FQCN_JAVA_STRING || type.resolve()?.qualifiedName == FQCN_KOTLIN_STRING
-    } else {
-      false
-    }
+    val isString =
+      if (type is PsiClassType) {
+        type.resolve()?.qualifiedName == FQCN_JAVA_STRING ||
+          type.resolve()?.qualifiedName == FQCN_KOTLIN_STRING
+      } else {
+        false
+      }
     return type is PsiPrimitiveType || isString
   }
 
@@ -113,11 +115,12 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
     val result = mutableListOf<PsiClass>()
 
     fun processType(t: PsiType) {
-      val unwrapped = when (t) {
-        is PsiWildcardType -> t.bound ?: return
-        is PsiCapturedWildcardType -> t.wildcard.bound ?: return
-        else -> t
-      }
+      val unwrapped =
+        when (t) {
+          is PsiWildcardType -> t.bound ?: return
+          is PsiCapturedWildcardType -> t.wildcard.bound ?: return
+          else -> t
+        }
 
       val psiClass = PsiTypesUtil.getPsiClass(unwrapped)
       if (psiClass != null) {

--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -63,14 +63,19 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
     val returnType = node.getExpressionType() ?: return
 
     // Skip checking primitive types and String
-    if (isPrimitiveOrString(returnType)) return
+    if (isJsonPrimitive(returnType)) return
 
     // Validate if the class is Moshi-compatible
     validateClassForMoshiCompatibility(context, node, returnType)
   }
 
-  private fun isPrimitiveOrString(type: PsiType): Boolean {
-    return type is PsiPrimitiveType || type.canonicalText == "java.lang.String"
+  private fun isJsonPrimitive(type: PsiType): Boolean {
+    val isString = if (type is PsiClassType) {
+      type.resolve()?.qualifiedName == FQCN_JAVA_STRING || type.resolve()?.qualifiedName == FQCN_KOTLIN_STRING
+    } else {
+      false
+    }
+    return type is PsiPrimitiveType || isString
   }
 
   private fun validateDeflateArguments(context: JavaContext, node: UCallExpression) {

--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -1,0 +1,151 @@
+package slack.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiModifier
+import com.intellij.psi.PsiPrimitiveType
+import com.intellij.psi.PsiType
+import org.jetbrains.uast.UCallExpression
+import slack.lint.util.sourceImplementation
+
+/**
+ * A detector that checks if a type passed into the JsonInflater.inflate/deflate methods follows Moshi's requirements
+ * for serialization/deserialization.
+ */
+class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
+
+  override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    return object : UElementHandler() {
+      override fun visitCallExpression(node: UCallExpression) {
+        if (isJsonInflaterInflateOrDeflate(node)) {
+          when (node.methodName) {
+            "inflate" -> validateInflateReturnType(context, node)
+            "deflate" -> validateDeflateArguments(context, node)
+          }
+        }
+      }
+    }
+  }
+
+  private fun isJsonInflaterInflateOrDeflate(node: UCallExpression): Boolean {
+    // Get the method being called
+    val method = node.resolve() ?: return false
+
+    // Check if it's from JsonInflater class
+    val containingClass = method.containingClass?.qualifiedName ?: return false
+    if (containingClass != FQCN_JSON_INFLATER) return false
+
+    // Check if it's an inflate or deflate method
+    return method.name == "inflate" || method.name == "deflate"
+  }
+
+  private fun validateInflateReturnType(context: JavaContext, node: UCallExpression) {
+    // Get the return type of the inflate call
+    val returnType = node.getExpressionType() ?: return
+
+    // Skip checking primitive types and String
+    if (isPrimitiveOrString(returnType)) return
+
+    // Get the class for the return type
+    val returnClass = context.evaluator.getTypeClass(returnType) ?: return
+
+    // Validate if the class is Moshi-compatible
+    validateClassForMoshiCompatibility(context, node, returnClass)
+  }
+
+  private fun isPrimitiveOrString(type: PsiType): Boolean {
+    return type is PsiPrimitiveType || type.canonicalText == "java.lang.String"
+  }
+
+  private fun validateDeflateArguments(context: JavaContext, node: UCallExpression) {
+    val method = node.resolve() ?: return
+    val parameters = method.parameterList.parameters
+    val arguments = node.valueArguments
+
+    for ((index, parameter) in parameters.withIndex()) {
+      if (parameter.name == "value" && index < arguments.size) {
+        val objectArgument = arguments[index]
+        // Get the type of the object being deflated
+        val objectType = objectArgument.getExpressionType() ?: return
+        val objectClass = context.evaluator.getTypeClass(objectType) ?: return
+
+        validateClassForMoshiCompatibility(context, node, objectClass)
+      }
+    }
+  }
+
+  private fun validateClassForMoshiCompatibility(context: JavaContext, node: UCallExpression, classToValidate: PsiClass) {
+    if (!isMoshiCompatible(classToValidate)) {
+      context.report(
+        issue = ISSUE_JSON_INFLATER_WITH_MOSHI_INCOMPATIBLE_TYPE,
+        location = context.getLocation(node),
+        message = ISSUE_JSON_INFLATER_WITH_MOSHI_INCOMPATIBLE_TYPE.getBriefDescription(TextFormat.TEXT)
+      )
+    }
+  }
+
+  private fun isMoshiCompatible(psiClass: PsiClass): Boolean {
+    if (!isInstantiable(psiClass)) return false
+
+    return hasPublicNoArgConstructor(psiClass) || hasJsonClassGenerateAdapter(psiClass) || hasAdaptedBy(psiClass)
+  }
+
+  private fun isInstantiable(psiClass: PsiClass): Boolean {
+    return !psiClass.isInterface
+            && !psiClass.hasModifierProperty(PsiModifier.ABSTRACT)
+            && !psiClass.isEnum
+            && psiClass.hasModifierProperty(PsiModifier.PUBLIC)
+  }
+
+  private fun hasPublicNoArgConstructor(psiClass: PsiClass): Boolean {
+    return psiClass.constructors.any { constructor ->
+      constructor.parameterList.parametersCount == 0 &&
+              constructor.hasModifierProperty(PsiModifier.PUBLIC)
+    }
+  }
+
+  private fun hasJsonClassGenerateAdapter(psiClass: PsiClass): Boolean {
+    return psiClass.annotations.any { annotation ->
+      annotation.qualifiedName == FQCN_JSON_CLASS &&
+              annotation.findDeclaredAttributeValue("generateAdapter")?.text == "true"
+    }
+  }
+
+  private fun hasAdaptedBy(psiClass: PsiClass): Boolean {
+    return psiClass.annotations.any { annotation -> annotation.qualifiedName == FQCN_ADAPTED_BY }
+  }
+
+  companion object {
+    // Fully qualified class names for relevant annotations and types
+    private const val FQCN_JSON_INFLATER = "slack.commons.json.JsonInflater"
+    private const val FQCN_JSON_CLASS = "com.squareup.moshi.JsonClass"
+    private const val FQCN_ADAPTED_BY = "dev.zacsweers.moshix.adapters.AdaptedBy"
+    
+    // Issue definitions
+    private val ISSUE_JSON_INFLATER_WITH_MOSHI_INCOMPATIBLE_TYPE =
+      Issue.create(
+        id = "JsonInflaterMoshiCompatibility:MoshiIncompatibleType",
+        "Using JsonInflater.inflate/deflate with a Moshi-incompatible type.",
+        """
+          Classes used with JsonInflater.inflate/deflate must be annotated with @JsonClass or @AdaptedBy to make it \
+          compatible with Moshi. Additionally, it cannot be an abstract class or an interface.
+        """
+          .trimIndent(),
+        Category.CORRECTNESS,
+        6,
+        Severity.ERROR,
+        implementation = sourceImplementation<JsonInflaterMoshiCompatibilityDetector>()
+      )
+    
+    fun issues(): List<Issue> = listOf(ISSUE_JSON_INFLATER_WITH_MOSHI_INCOMPATIBLE_TYPE)
+  }
+}

--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -34,8 +34,10 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
   override fun createUastHandler(context: JavaContext): UElementHandler {
     return object : UElementHandler() {
       override fun visitCallExpression(node: UCallExpression) {
+        val method = node.resolve() ?: return
+
         if (isJsonInflaterInflateOrDeflate(node)) {
-          when (node.methodName) {
+          when (method.name) {
             "inflate" -> validateInflateReturnType(context, node)
             "deflate" -> validateDeflateArguments(context, node)
           }

--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -19,6 +19,7 @@ import com.intellij.psi.PsiType
 import com.intellij.psi.PsiWildcardType
 import com.intellij.psi.util.PsiTypesUtil
 import org.jetbrains.uast.UCallExpression
+import slack.lint.moshi.MoshiLintUtil.hasMoshiAnnotation
 import slack.lint.util.sourceImplementation
 
 /**
@@ -139,9 +140,7 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
 
     if (!isInstantiable(psiClass)) return false
 
-    return hasPublicNoArgConstructor(psiClass) ||
-      hasJsonClassGenerateAdapter(psiClass) ||
-      hasAdaptedBy(psiClass)
+    return hasPublicNoArgConstructor(psiClass) || psiClass.hasMoshiAnnotation()
   }
 
   private fun isCollectionType(psiClass: PsiClass): Boolean {
@@ -163,22 +162,11 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
     }
   }
 
-  private fun hasJsonClassGenerateAdapter(psiClass: PsiClass): Boolean {
-    return psiClass.annotations.any { annotation ->
-      annotation.qualifiedName == FQCN_JSON_CLASS &&
-        annotation.findDeclaredAttributeValue("generateAdapter")?.text == "true"
-    }
-  }
-
-  private fun hasAdaptedBy(psiClass: PsiClass): Boolean {
-    return psiClass.annotations.any { annotation -> annotation.qualifiedName == FQCN_ADAPTED_BY }
-  }
-
   companion object {
     // Fully qualified class names for relevant annotations and types
     private const val FQCN_JSON_INFLATER = "slack.commons.json.JsonInflater"
-    private const val FQCN_JSON_CLASS = "com.squareup.moshi.JsonClass"
-    private const val FQCN_ADAPTED_BY = "dev.zacsweers.moshix.adapters.AdaptedBy"
+    private const val FQCN_JAVA_STRING = "java.lang.String"
+    private const val FQCN_KOTLIN_STRING = "kotlin.String"
     private const val FQCN_LIST = "java.util.List"
     private const val FQCN_SET = "java.util.Set"
     private const val FQCN_MAP = "java.util.Map"

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -316,10 +316,10 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
       .run()
       .expect(
         """
-                src/test/InvalidModel.kt:19: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiCompatibility:MoshiIncompatibleType]
+                src/test/InvalidModel.kt:19: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
                             val model = jsonInflater.inflate<List<InvalidModel>>("{}", type)
                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                src/test/InvalidModel.kt:20: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiCompatibility:MoshiIncompatibleType]
+                src/test/InvalidModel.kt:20: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
                             val json = jsonInflater.deflate(model, type)
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 2 errors
@@ -356,10 +356,10 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
       .run()
       .expect(
         """
-        src/test/InvalidModel.kt:13: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiCompatibility:MoshiIncompatibleType]
+        src/test/InvalidModel.kt:13: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
                     val model = jsonInflater.inflate("{}", InvalidModel::class.java)
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        src/test/InvalidModel.kt:14: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiCompatibility:MoshiIncompatibleType]
+        src/test/InvalidModel.kt:14: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
                     val json = jsonInflater.deflate(model, InvalidModel::class.java)
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         2 errors
@@ -430,10 +430,10 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
       .run()
       .expect(
         """
-        src/test/InvalidModel.kt:15: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiCompatibility:MoshiIncompatibleType]
+        src/test/InvalidModel.kt:15: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
                     val model = jsonInflater.inflate("{}", InvalidModel::class.java)
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        src/test/InvalidModel.kt:16: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiCompatibility:MoshiIncompatibleType]
+        src/test/InvalidModel.kt:16: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
                     val json = jsonInflater.deflate(model, InvalidModel::class.java)
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         2 errors

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -1,0 +1,266 @@
+package slack.lint
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
+
+  override fun getDetector(): Detector {
+    return JsonInflaterMoshiCompatibilityDetector()
+  }
+
+  override fun getIssues(): List<Issue> {
+    return JsonInflaterMoshiCompatibilityDetector.issues()
+  }
+
+  // Stubs for required annotations and classes
+  private val jsonClassStub = java("""
+    package com.squareup.moshi;
+    
+    import java.lang.annotation.Retention;
+    import java.lang.annotation.RetentionPolicy;
+    
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface JsonClass {
+        boolean generateAdapter();
+    }
+  """
+  )
+
+  private val jsonStub = java("""
+    package com.squareup.moshi;
+    
+    import java.lang.annotation.Retention;
+    import java.lang.annotation.RetentionPolicy;
+    
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Json {
+        String name();
+    }
+  """
+  )
+
+  private val adaptedByStub = kotlin("""
+    package dev.zacsweers.moshix.adapters
+    
+    import java.lang.annotation.Retention
+    import java.lang.annotation.RetentionPolicy
+    
+    @Retention(RetentionPolicy.RUNTIME)
+    public annotation class AdaptedBy(val adapter: KClass<*>, val nullSafe: Boolean = true)
+  """
+  )
+
+  private val jsonInflaterStub = kotlin("""
+    package slack.commons.json
+
+    interface JsonInflater {
+      fun <T : Any> inflate(jsonData: String, clazz: Class<T>): T
+    
+      fun <T : Any> deflate(value: T, clazz: Class<T>): String
+    
+      fun deflate(value: Any, type: Type): String
+    }
+  """
+  )
+
+
+  @Test
+  fun testDataClassJsonClassTrue() {
+    lint().files(
+      jsonClassStub,
+      jsonStub,
+      jsonInflaterStub,
+      kotlin("""
+        package test
+        
+        import com.squareup.moshi.JsonClass
+        
+        @JsonClass(generateAdapter = true)
+        data class ValidModel(
+            val id: String,
+            val name: String,
+            val count: Int
+        )
+        
+        fun useJsonInflater(jsonInflater: slack.commons.json.JsonInflater) {
+            val model = jsonInflater.inflate("{}", ValidModel::class.java)
+            val json = jsonInflater.deflate(model)
+        }
+      """
+      )
+    )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun testDataClassAdaptedBy() {
+    lint().files(
+      jsonClassStub,
+      jsonStub,
+      jsonInflaterStub,
+      adaptedByStub,
+      kotlin("""
+        package test
+        
+        import dev.zacsweers.moshix.adapters.AdaptedBy
+        
+        @AdaptedBy(String::class)
+        data class ValidModel(
+            val id: String,
+            val name: String,
+            val count: Int
+        )
+        
+        fun useJsonInflater(jsonInflater: slack.commons.json.JsonInflater) {
+            val model = jsonInflater.inflate("{}", ValidModel::class.java)
+            val json = jsonInflater.deflate(model)
+        }
+      """
+      )
+    )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun testDataClassJsonClassFalse() {
+    lint().files(
+      jsonClassStub,
+      jsonStub,
+      jsonInflaterStub,
+      kotlin("""
+        package test
+        
+        import com.squareup.moshi.JsonClass
+        
+        @JsonClass(generateAdapter = false)
+        data class ValidModel(
+            val id: String,
+            val name: String,
+            val count: Int
+        )
+        
+        fun useJsonInflater(jsonInflater: slack.commons.json.JsonInflater) {
+            val model = jsonInflater.inflate("{}", ValidModel::class.java)
+            val json = jsonInflater.deflate(model)
+        }
+      """
+      )
+    )
+      .run()
+      .expect("""
+        src/test/ValidModel.kt:14: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiCompatibility:MoshiIncompatibleType]
+                    val model = jsonInflater.inflate("{}", ValidModel::class.java)
+                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test/ValidModel.kt:15: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiCompatibility:MoshiIncompatibleType]
+                    val json = jsonInflater.deflate(model)
+                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        2 errors
+      """
+      )
+  }
+
+  @Test
+  fun testMissingJsonClassAnnotation() {
+    lint().files(
+      jsonClassStub,
+      jsonStub,
+      jsonInflaterStub,
+      kotlin("""
+        package test
+        
+        data class InvalidModel(
+            val id: String,
+            val name: String,
+            val count: Int
+        )
+        
+        fun useJsonInflater(jsonInflater: slack.commons.json.JsonInflater) {
+            val model = jsonInflater.inflate("{}", InvalidModel::class.java)
+            val json = jsonInflater.deflate(model)
+        }
+      """)
+    ).run()
+      .expect("""
+        src/test/InvalidModel.kt:11: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiCompatibility:MoshiIncompatibleType]
+                    val model = jsonInflater.inflate("{}", InvalidModel::class.java)
+                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test/InvalidModel.kt:12: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiCompatibility:MoshiIncompatibleType]
+                    val json = jsonInflater.deflate(model)
+                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        2 errors
+      """
+      )
+  }
+
+  @Test
+  fun testNonDataClass() {
+    lint().files(
+      jsonClassStub,
+      jsonStub,
+      jsonInflaterStub,
+      kotlin("""
+        package test
+
+        import com.squareup.moshi.JsonClass
+
+        @JsonClass(generateAdapter = true)
+        class InvalidModel(
+            val id: String,
+            val name: String,
+            val count: Int
+        )
+
+        fun useJsonInflater(jsonInflater: slack.commons.json.JsonInflater) {
+            val model = jsonInflater.inflate("{}", InvalidModel::class.java)
+            val json = jsonInflater.deflate(model)
+        }
+      """)
+    )
+      .run()
+      .expectClean()
+  }
+  @Test
+  fun testAbstractClass() {
+    lint().files(
+      jsonClassStub,
+      jsonStub,
+      jsonInflaterStub,
+      kotlin("""
+        package test
+
+        import com.squareup.moshi.JsonClass
+
+        @JsonClass(generateAdapter = true)
+        abstract class InvalidModel(
+            val id: String,
+            val name: String,
+            val count: Int
+        )
+
+        fun useJsonInflater(jsonInflater: slack.commons.json.JsonInflater) {
+            val model = jsonInflater.inflate("{}", InvalidModel::class.java)
+            val json = jsonInflater.deflate(model)
+        }
+      """)
+    )
+      .run()
+      .expect("""
+        src/test/InvalidModel.kt:14: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiCompatibility:MoshiIncompatibleType]
+                    val model = jsonInflater.inflate("{}", InvalidModel::class.java)
+                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        src/test/InvalidModel.kt:15: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiCompatibility:MoshiIncompatibleType]
+                    val json = jsonInflater.deflate(model)
+                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        2 errors
+      """
+      )
+  }
+}

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -105,6 +105,11 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     )
 
   @Test
+  fun testDocumentationExample() {
+    testMissingJsonClassAnnotation()
+  }
+
+  @Test
   fun testDataClassJsonClassTrue() {
     lint()
       .files(


### PR DESCRIPTION
This PR creates a new detector, `JsonInflaterMoshiCompatibilityDetector`, to ensure that any class that is used with `JsonInflater.inflate()` or `JsonInflater.deflate()` is annotated with `JsonClass` or `AdaptedBy` to make it compatible with Moshi.
