### PR TITLE
Return false instead of calling super in RxObservableEmitDetector

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/rx/RxObservableEmitDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/rx/RxObservableEmitDetector.kt
@@ -43,7 +43,7 @@ class RxObservableEmitDetector : Detector(), SourceCodeScanner {
                 sendCalled = true
               }
 
-              return super.visitCallExpression(node)
+              return false
             }
           }
 


### PR DESCRIPTION
###  Summary

This PR fixes a bug where lint builds would fail due to the following error:
`Message: You must override visitCallExpression (and don't call super.visitCallExpression!)`

Resolves #400
