### PR TITLE
Circuit: Screen class detector

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/CircuitScreenDataClassDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/CircuitScreenDataClassDetector.kt
@@ -76,8 +76,6 @@ class CircuitScreenDataClassDetector : Detector(), SourceCodeScanner {
                 .with(replacement)
                 .reformat(true)
                 .build()
-
-            // update location to the keyword
             context.report(ISSUE, keywordLocation, MESSAGE, quickFix)
           }
         }

--- a/slack-lint-checks/src/main/java/slack/lint/CircuitScreenDataClassDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/CircuitScreenDataClassDetector.kt
@@ -1,0 +1,110 @@
+// Copyright (C) 2025 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.getUMethod
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import slack.lint.util.implements
+import slack.lint.util.sourceImplementation
+
+class CircuitScreenDataClassDetector : Detector(), SourceCodeScanner {
+  override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(UClass::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    return object : UElementHandler() {
+
+      override fun visitClass(node: UClass) {
+        val sourceNode = node.sourcePsi as? KtClassOrObject ?: return
+
+        val isInterface = node.isInterface
+        // Open classes cannot be "data" classes
+        val isOpen = sourceNode.hasModifier(KtTokens.OPEN_KEYWORD)
+        // Screens must be parcelable and inner classes cannot be parcelable
+        val isInner = sourceNode.hasModifier(KtTokens.INNER_KEYWORD)
+        // Cannot have abstract data class / object
+        val isAbstract = sourceNode.hasModifier(KtTokens.ABSTRACT_KEYWORD)
+        // Cannot have sealed data class / object
+        val isSealed = sourceNode.hasModifier(KtTokens.SEALED_KEYWORD)
+        // Cannot have companion data object
+        val isCompanionObject = sourceNode.hasModifier(KtTokens.COMPANION_KEYWORD)
+
+        val isApplicableClass =
+          !isOpen && !isCompanionObject && !isInterface && !isInner && !isAbstract && !isSealed
+
+        if (isApplicableClass && node.implements(QUALIFIED_CIRCUIT_SCREEN)) {
+          val isDataClass = sourceNode.isData()
+
+          if (!isDataClass) {
+            val hasProperties =
+              !node.constructors
+                .asSequence()
+                .mapNotNull { it.getUMethod() }
+                .firstOrNull { it.sourcePsi is KtPrimaryConstructor }
+                ?.uastParameters
+                .isNullOrEmpty()
+            val classKeyword =
+              when (sourceNode) {
+                is KtClass -> sourceNode.getClassKeyword()
+                is KtObjectDeclaration -> sourceNode.getObjectKeyword() ?: return
+                else -> return
+              }
+            val isObject = classKeyword?.node?.elementType == KtTokens.OBJECT_KEYWORD
+            val originalKeyword = if (isObject) KtTokens.OBJECT_KEYWORD else KtTokens.CLASS_KEYWORD
+            val replacement =
+              if (hasProperties) "${KtTokens.DATA_KEYWORD} ${KtTokens.CLASS_KEYWORD}"
+              else "${KtTokens.DATA_KEYWORD} ${KtTokens.OBJECT_KEYWORD}"
+            val keywordLocation = context.getLocation(classKeyword)
+            val quickFix =
+              fix()
+                .replace()
+                .name("Replace with $replacement")
+                .range(keywordLocation)
+                .text(originalKeyword.value)
+                .with(replacement)
+                .reformat(true)
+                .build()
+
+            // update location to the keyword
+            context.report(ISSUE, keywordLocation, MESSAGE, quickFix)
+          }
+        }
+      }
+    }
+  }
+
+  companion object {
+    const val QUALIFIED_CIRCUIT_SCREEN = "com.slack.circuit.runtime.screen.Screen"
+    const val MESSAGE =
+      "Circuit Screen implementations should be data classes or data objects, not regular classes."
+    const val ISSUE_ID = "CircuitScreenShouldBeDataClass"
+    const val BRIEF_DESCRIPTION = "Circuit Screen should be a data class or data object"
+    const val EXPLANATION =
+      """Circuit Screen implementations should be data classes or data objects to ensure proper
+equality, hashCode, and toString implementations. Regular classes can cause issues with
+screen comparison and navigation."""
+
+    val ISSUE: Issue =
+      Issue.create(
+        ISSUE_ID,
+        BRIEF_DESCRIPTION,
+        EXPLANATION,
+        Category.CORRECTNESS,
+        8,
+        Severity.ERROR,
+        sourceImplementation<CircuitScreenDataClassDetector>(),
+      )
+  }
+}

--- a/slack-lint-checks/src/main/java/slack/lint/SlackIssueRegistry.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/SlackIssueRegistry.kt
@@ -76,5 +76,6 @@ class SlackIssueRegistry : IssueRegistry() {
     add(ItemDecorationViewBindingDetector.ISSUE)
     add(NullableConcurrentHashMapDetector.ISSUE)
     addAll(AlwaysNullReadOnlyVariableDetector.ISSUES)
+    add(CircuitScreenDataClassDetector.ISSUE)
   }
 }

--- a/slack-lint-checks/src/test/java/slack/lint/CircuitScreenDataClassDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/CircuitScreenDataClassDetectorTest.kt
@@ -1,0 +1,396 @@
+// Copyright (C) 2025 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint
+
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import org.junit.Test
+
+class CircuitScreenDataClassDetectorTest : BaseSlackLintTest() {
+
+  override fun getDetector(): Detector = CircuitScreenDataClassDetector()
+
+  override fun getIssues(): List<Issue> = listOf(CircuitScreenDataClassDetector.ISSUE)
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - regular class implements Screen - fails`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            import com.slack.circuit.runtime.screen.Screen
+
+            @Parcelize
+            class HomeScreen(val userId: String) : Screen {
+                data class State(message: String) : State
+            }
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint()
+      .files(circuitScreenStub, testFile)
+      .run()
+      .expect(
+        """
+        src/com/example/screens/HomeScreen.kt:6: Error: ${CircuitScreenDataClassDetector.MESSAGE} [${CircuitScreenDataClassDetector.ISSUE_ID}]
+        class HomeScreen(val userId: String) : Screen {
+        ~~~~~
+        1 error
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - data class implements Screen - succeeds`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            import com.slack.circuit.runtime.screen.Screen
+
+            data class HomeScreen(val userId: String) : Screen
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint().files(circuitScreenStub, testFile).run().expectClean()
+  }
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - data object implements Screen - succeeds`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            import com.slack.circuit.runtime.screen.Screen
+
+            data object SettingsScreen : Screen
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint().files(circuitScreenStub, testFile).run().expectClean()
+  }
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - interface extends Screen - succeeds`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            import com.slack.circuit.runtime.screen.Screen
+
+            interface CustomScreen : Screen {
+              val id: String
+            }
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint().files(circuitScreenStub, testFile).run().expectClean()
+  }
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - regular class not implementing Screen - succeeds`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            class HomeViewModel(val userId: String)
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint().files(testFile).run().expectClean()
+  }
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - class name contains 'class' keyword - only replaces declaration`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            import com.slack.circuit.runtime.screen.Screen
+
+            class MyClassScreen(val id: String) : Screen
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint()
+      .files(circuitScreenStub, testFile)
+      .run()
+      .expect(
+        """
+        src/com/example/screens/MyClassScreen.kt:5: Error: ${CircuitScreenDataClassDetector.MESSAGE} [${CircuitScreenDataClassDetector.ISSUE_ID}]
+        class MyClassScreen(val id: String) : Screen
+        ~~~~~
+        1 error
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - regular object class implements Screen - suggests data object`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            import com.slack.circuit.runtime.screen.Screen
+
+            object SettingsScreen : Screen
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint()
+      .files(circuitScreenStub, testFile)
+      .run()
+      .expect(
+        """
+        src/com/example/screens/SettingsScreen.kt:5: Error: ${CircuitScreenDataClassDetector.MESSAGE} [${CircuitScreenDataClassDetector.ISSUE_ID}]
+        object SettingsScreen : Screen
+        ~~~~~~
+        1 error
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - open class implements Screen - succeeds`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            import com.slack.circuit.runtime.screen.Screen
+
+            open class ProfileScreen(val userId: String) : Screen
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint().files(circuitScreenStub, testFile).run().expectClean()
+  }
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - companion object implements Screen - fails`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            import com.slack.circuit.runtime.screen.Screen
+
+            class SomeClass {
+                companion object NavScreen : Screen
+            }
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint().files(circuitScreenStub, testFile).run().expectClean()
+  }
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - nested class implements Screen - fails`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            import com.slack.circuit.runtime.screen.Screen
+
+            class OuterClass {
+                class NestedScreen(val id: String) : Screen
+            }
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint()
+      .files(circuitScreenStub, testFile)
+      .run()
+      .expect(
+        """
+        src/com/example/screens/OuterClass.kt:6: Error: ${CircuitScreenDataClassDetector.MESSAGE} [${CircuitScreenDataClassDetector.ISSUE_ID}]
+            class NestedScreen(val id: String) : Screen
+            ~~~~~
+        1 error
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - abstract class implements Screen - succeeds`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            import com.slack.circuit.runtime.screen.Screen
+
+            abstract class BaseScreen : Screen {
+                abstract val screenId: String
+            }
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint().files(circuitScreenStub, testFile).run().expectClean()
+  }
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - sealed class implements Screen - fails`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            import com.slack.circuit.runtime.screen.Screen
+
+            sealed class NavigationScreen : Screen {
+                data class Home(val userId: String) : NavigationScreen()
+                data object Settings : NavigationScreen()
+            }
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint()
+      .files(circuitScreenStub, testFile)
+      .run()
+      .expect(
+        """
+        src/com/example/screens/NavigationScreen.kt:5: Error: ${CircuitScreenDataClassDetector.MESSAGE} [${CircuitScreenDataClassDetector.ISSUE_ID}]
+        sealed class NavigationScreen : Screen {
+               ~~~~~
+        1 error
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - inner class implements Screen - succeeds`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            import com.slack.circuit.runtime.screen.Screen
+
+            class OuterClass {
+                class InnerScreen(val id: String) : Screen
+            }
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint()
+      .files(circuitScreenStub, testFile)
+      .run()
+      .expect(
+        "src/com/example/screens/OuterClass.kt:6: Error: Circuit Screen implementations should be data classes or data objects, not regular classes. [CircuitScreenShouldBeDataClass]\n" +
+          "    class InnerScreen(val id: String) : Screen\n" +
+          "    ~~~~~\n" +
+          "1 error"
+      )
+  }
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - class with no constructor parameters - suggests data object`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            import com.slack.circuit.runtime.screen.Screen
+
+            class EmptyScreen : Screen
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint()
+      .files(circuitScreenStub, testFile)
+      .run()
+      .expect(
+        """
+        src/com/example/screens/EmptyScreen.kt:5: Error: ${CircuitScreenDataClassDetector.MESSAGE} [${CircuitScreenDataClassDetector.ISSUE_ID}]
+        class EmptyScreen : Screen
+        ~~~~~
+        1 error
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `Test CircuitScreenDataClassDetector - class with empty constructor - suggests data object`() {
+    val testFile =
+      kotlin(
+          """
+            package com.example.screens
+
+            import com.slack.circuit.runtime.screen.Screen
+
+            class EmptyScreen() : Screen
+        """
+            .trimIndent()
+        )
+        .indented()
+
+    lint()
+      .files(circuitScreenStub, testFile)
+      .run()
+      .expect(
+        """
+        src/com/example/screens/EmptyScreen.kt:5: Error: ${CircuitScreenDataClassDetector.MESSAGE} [${CircuitScreenDataClassDetector.ISSUE_ID}]
+        class EmptyScreen() : Screen
+        ~~~~~
+        1 error
+        """
+          .trimIndent()
+      )
+  }
+
+  private val circuitScreenStub =
+    kotlin(
+        """
+            package com.slack.circuit.runtime.screen
+
+            import android.os.Parcelable
+
+            interface Screen : Parcelable
+        """
+          .trimIndent()
+      )
+      .indented()
+}

--- a/slack-lint-checks/src/test/java/slack/lint/CircuitScreenDataClassDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/CircuitScreenDataClassDetectorTest.kt
@@ -284,15 +284,7 @@ class CircuitScreenDataClassDetectorTest : BaseSlackLintTest() {
     lint()
       .files(circuitScreenStub, testFile)
       .run()
-      .expect(
-        """
-        src/com/example/screens/NavigationScreen.kt:5: Error: ${CircuitScreenDataClassDetector.MESSAGE} [${CircuitScreenDataClassDetector.ISSUE_ID}]
-        sealed class NavigationScreen : Screen {
-               ~~~~~
-        1 error
-        """
-          .trimIndent()
-      )
+      .expectClean()
   }
 
   @Test

--- a/slack-lint-checks/src/test/java/slack/lint/CircuitScreenDataClassDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/CircuitScreenDataClassDetectorTest.kt
@@ -281,10 +281,7 @@ class CircuitScreenDataClassDetectorTest : BaseSlackLintTest() {
         )
         .indented()
 
-    lint()
-      .files(circuitScreenStub, testFile)
-      .run()
-      .expectClean()
+    lint().files(circuitScreenStub, testFile).run().expectClean()
   }
 
   @Test


### PR DESCRIPTION
### What
We had a lot of instances where circuit screens would be created with regular "class" objects. These should be data classes / objects to ensure proper `equals()` handling, which can result in bugs related to new instance equality checks. 

### How
The new `CircuitScreenDataClassDetector` class first checks that the class is an applicable class that implements `Screen`. For example, interfaces cannot be "data interface" or an open class cannot be an "open data class". 

We also offer a quick fix that will locate the class keyword position and replace it with either "data class" or "data object" based on whether an available constructor has any arguments.

### Screenshots / Video

Notice that the first class declarations do not show a lint error. 

<img width="484" height="401" alt="Screenshot 2025-07-16 at 3 12 29 PM" src="https://github.com/user-attachments/assets/5068cf5e-a301-4c79-84a7-21f1fd1101e2" />

Quick fixes in action

https://github.com/user-attachments/assets/d6ab0e50-420a-4140-b1ee-69ac6cceeeb4


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
