### PR TITLE
Register JsonInflaterMoshiCompatibilityDetector with SlackIssueRegistry

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -102,10 +102,9 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
 
     if (modelClasses.any { !isMoshiCompatible(it) }) {
       context.report(
-        issue = ISSUE_JSON_INFLATER_WITH_MOSHI_INCOMPATIBLE_TYPE,
+        issue = ISSUE,
         location = context.getLocation(node),
-        message =
-          ISSUE_JSON_INFLATER_WITH_MOSHI_INCOMPATIBLE_TYPE.getBriefDescription(TextFormat.TEXT),
+        message = ISSUE.getBriefDescription(TextFormat.TEXT),
       )
     }
   }
@@ -166,8 +165,7 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
     private const val FQCN_MAP = "java.util.Map"
     private const val FQCN_COLLECTION = "java.util.Collection"
 
-    // Issue definitions
-    private val ISSUE_JSON_INFLATER_WITH_MOSHI_INCOMPATIBLE_TYPE =
+    val ISSUE =
       Issue.create(
         id = "JsonInflaterMoshiIncompatibleType",
         "Using JsonInflater.inflate/deflate with a Moshi-incompatible type.",
@@ -177,10 +175,8 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
         """,
         Category.CORRECTNESS,
         6,
-        Severity.IGNORE,
+        Severity.ERROR,
         implementation = sourceImplementation<JsonInflaterMoshiCompatibilityDetector>(),
       )
-
-    fun issues(): List<Issue> = listOf(ISSUE_JSON_INFLATER_WITH_MOSHI_INCOMPATIBLE_TYPE)
   }
 }

--- a/slack-lint-checks/src/main/java/slack/lint/SlackIssueRegistry.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/SlackIssueRegistry.kt
@@ -77,5 +77,6 @@ class SlackIssueRegistry : IssueRegistry() {
     add(NullableConcurrentHashMapDetector.ISSUE)
     addAll(AlwaysNullReadOnlyVariableDetector.ISSUES)
     add(CircuitScreenDataClassDetector.ISSUE)
+    add(JsonInflaterMoshiCompatibilityDetector.ISSUE)
   }
 }


### PR DESCRIPTION
###  Summary

This PR adds `JsonInflaterMoshiCompatibilityDetector` to `SlackIssueRegistry`

### Requirements (place an `x` in each `[ ]`)

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [ ] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
