### PR TITLE
Allow sealed interfaces to be Moshi-compatible

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -143,7 +143,7 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
 
     if (isAbstractOrNonPublicClass(psiClass)) return false
 
-    if (isNonSealedInterface(psiClass)) return false
+    if (psiClass.isInterface && !isSealedInterface(psiClass)) return false
 
     return psiClass.hasMoshiAnnotation()
   }
@@ -159,17 +159,17 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
         !psiClass.hasModifierProperty(PsiModifier.PUBLIC))
   }
 
-  private fun isNonSealedInterface(psiClass: PsiClass): Boolean {
+  private fun isSealedInterface(psiClass: PsiClass): Boolean {
     if (!psiClass.isInterface) return false
 
     // For Kotlin classes, check using Kotlin PSI
     if (psiClass is KtLightClass) {
       val ktClass = psiClass.kotlinOrigin
-      return ktClass?.hasModifier(KtTokens.SEALED_KEYWORD) != true
+      return ktClass?.hasModifier(KtTokens.SEALED_KEYWORD) == true
     }
 
     // Fallback for Java classes
-    return !psiClass.hasModifierProperty(PsiModifier.SEALED)
+    return psiClass.hasModifierProperty(PsiModifier.SEALED)
   }
 
   companion object {

--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -152,7 +152,6 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
   private fun isInstantiable(psiClass: PsiClass): Boolean {
     return !psiClass.isInterface &&
       !psiClass.hasModifierProperty(PsiModifier.ABSTRACT) &&
-      !psiClass.isEnum &&
       psiClass.hasModifierProperty(PsiModifier.PUBLIC)
   }
 

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -538,7 +538,7 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
             @JsonClass(generateAdapter = true)
             data class Cat(val age: Int) : Animal
 
-            @DefaultNull
+            @DefaultObject
             object Default : Animal
         }
 

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -36,21 +36,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
   """
     )
 
-  private val jsonStub =
-    java(
-      """
-    package com.squareup.moshi;
-
-    import java.lang.annotation.Retention;
-    import java.lang.annotation.RetentionPolicy;
-
-    @Retention(RetentionPolicy.RUNTIME)
-    public @interface Json {
-        String name();
-    }
-  """
-    )
-
   private val adaptedByStub =
     kotlin(
       """
@@ -114,7 +99,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         kotlin(
           """
@@ -146,7 +130,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         kotlin(
           """
@@ -180,7 +163,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         kotlin(
           """
@@ -212,7 +194,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         adaptedByStub,
         kotlin(
@@ -245,7 +226,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         adaptedByStub,
         parameterizedTypeStub,
@@ -284,7 +264,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         adaptedByStub,
         parameterizedTypeStub,
@@ -331,8 +310,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
   fun testMissingJsonClassAnnotation() {
     lint()
       .files(
-        jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         kotlin(
           """
@@ -372,7 +349,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         kotlin(
           """
@@ -404,7 +380,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         kotlin(
           """
@@ -440,4 +415,79 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
       """
       )
   }
+
+    @Test
+    fun testEnumClass() {
+        lint()
+            .files(
+                jsonClassStub,
+                jsonInflaterStub,
+                kotlin(
+                    """
+        package test
+
+        import com.squareup.moshi.JsonClass
+        import slack.commons.json.JsonInflater
+
+        @JsonClass(generateAdapter = false)
+        enum class ValidEnum {
+            UNKNOWN,
+            UP,
+            DOWN,
+            LEFT,
+            RIGHT
+        }
+
+        fun useJsonInflater(jsonInflater: JsonInflater) {
+            val model = jsonInflater.inflate("{}", ValidEnum::class.java)
+            val json = jsonInflater.deflate(model, ValidEnum::class.java)
+        }
+      """
+                ),
+            )
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun testEnumClassMissingJsonClassAnnotation() {
+        lint()
+            .files(
+                jsonClassStub,
+                jsonInflaterStub,
+                kotlin(
+                    """
+        package test
+
+        import com.squareup.moshi.JsonClass
+        import slack.commons.json.JsonInflater
+
+        enum class ValidEnum {
+            UNKNOWN,
+            UP,
+            DOWN,
+            LEFT,
+            RIGHT
+        }
+
+        fun useJsonInflater(jsonInflater: JsonInflater) {
+            val model = jsonInflater.inflate("{}", ValidEnum::class.java)
+            val json = jsonInflater.deflate(model, ValidEnum::class.java)
+        }
+      """
+                ),
+            )
+            .run()
+            .expect(
+                """
+            src/test/ValidEnum.kt:16: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
+                        val model = jsonInflater.inflate("{}", ValidEnum::class.java)
+                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            src/test/ValidEnum.kt:17: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
+                        val json = jsonInflater.deflate(model, ValidEnum::class.java)
+                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            2 errors
+      """
+            )
+    }
 }

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -416,14 +416,14 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
       )
   }
 
-    @Test
-    fun testEnumClass() {
-        lint()
-            .files(
-                jsonClassStub,
-                jsonInflaterStub,
-                kotlin(
-                    """
+  @Test
+  fun testEnumClass() {
+    lint()
+      .files(
+        jsonClassStub,
+        jsonInflaterStub,
+        kotlin(
+          """
         package test
 
         import com.squareup.moshi.JsonClass
@@ -443,20 +443,20 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
             val json = jsonInflater.deflate(model, ValidEnum::class.java)
         }
       """
-                ),
-            )
-            .run()
-            .expectClean()
-    }
+        ),
+      )
+      .run()
+      .expectClean()
+  }
 
-    @Test
-    fun testEnumClassMissingJsonClassAnnotation() {
-        lint()
-            .files(
-                jsonClassStub,
-                jsonInflaterStub,
-                kotlin(
-                    """
+  @Test
+  fun testEnumClassMissingJsonClassAnnotation() {
+    lint()
+      .files(
+        jsonClassStub,
+        jsonInflaterStub,
+        kotlin(
+          """
         package test
 
         import com.squareup.moshi.JsonClass
@@ -475,11 +475,11 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
             val json = jsonInflater.deflate(model, ValidEnum::class.java)
         }
       """
-                ),
-            )
-            .run()
-            .expect(
-                """
+        ),
+      )
+      .run()
+      .expect(
+        """
             src/test/ValidEnum.kt:16: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
                         val model = jsonInflater.inflate("{}", ValidEnum::class.java)
                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -488,6 +488,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             2 errors
       """
-            )
-    }
+      )
+  }
 }

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -89,6 +89,26 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
         .trimIndent()
     )
 
+  private val typeLabelStub =
+    kotlin(
+        """
+      package dev.zacsweers.moshix.sealed.annotations
+
+      annotation class TypeLabel(val label: String, val alternateLabels: Array<String> = [])
+    """
+      )
+      .indented()
+
+  private val defaultObjectStub =
+    kotlin(
+        """
+      package dev.zacsweers.moshix.sealed.annotations
+
+      annotation class DefaultObject
+    """
+      )
+      .indented()
+
   @Test
   fun testDocumentationExample() {
     testMissingJsonClassAnnotation()
@@ -486,6 +506,151 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
             src/test/ValidEnum.kt:17: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
                         val json = jsonInflater.deflate(model, ValidEnum::class.java)
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            2 errors
+      """
+      )
+  }
+
+  @Test
+  fun testNonSealedInterface() {
+    lint()
+      .files(
+        jsonClassStub,
+        jsonInflaterStub,
+        typeLabelStub,
+        defaultObjectStub,
+        kotlin(
+          """
+        package test
+
+        import com.squareup.moshi.JsonClass
+        import slack.commons.json.JsonInflater
+        import dev.zacsweers.moshix.sealed.annotations.TypeLabel
+        import dev.zacsweers.moshix.sealed.annotations.DefaultObject
+
+        @JsonClass(generateAdapter = true, generator = "sealed:type")
+        interface Animal {
+            @TypeLabel("dog")
+            @JsonClass(generateAdapter = true)
+            data class Dog(val name: String) : Animal
+
+            @TypeLabel("cat")
+            @JsonClass(generateAdapter = true)
+            data class Cat(val age: Int) : Animal
+
+            @DefaultNull
+            object Default : Animal
+        }
+
+        fun useJsonInflater(jsonInflater: JsonInflater) {
+            val model = jsonInflater.inflate("{}", Animal::class.java)
+            val json = jsonInflater.deflate(model, Animal::class.java)
+        }
+      """
+        ),
+      )
+      .run()
+      .expect(
+        """
+            src/test/Animal.kt:24: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
+                        val model = jsonInflater.inflate("{}", Animal::class.java)
+                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            src/test/Animal.kt:25: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
+                        val json = jsonInflater.deflate(model, Animal::class.java)
+                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            2 errors
+      """
+      )
+  }
+
+  @Test
+  fun testSealedInterface() {
+    lint()
+      .files(
+        jsonClassStub,
+        jsonInflaterStub,
+        typeLabelStub,
+        defaultObjectStub,
+        kotlin(
+          """
+        package test
+
+        import com.squareup.moshi.JsonClass
+        import slack.commons.json.JsonInflater
+        import dev.zacsweers.moshix.sealed.annotations.TypeLabel
+        import dev.zacsweers.moshix.sealed.annotations.DefaultObject
+
+        @JsonClass(generateAdapter = true, generator = "sealed:type")
+        sealed interface Animal {
+            @TypeLabel("dog")
+            @JsonClass(generateAdapter = true)
+            data class Dog(val name: String) : Animal
+
+            @TypeLabel("cat")
+            @JsonClass(generateAdapter = true)
+            data class Cat(val age: Int) : Animal
+
+            @DefaultObject
+            object Default : Animal
+        }
+
+        fun useJsonInflater(jsonInflater: JsonInflater) {
+            val model = jsonInflater.inflate("{}", Animal::class.java)
+            val json = jsonInflater.deflate(model, Animal::class.java)
+        }
+      """
+        ),
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun testSealedInterfaceMissingJsonClassAnnotation() {
+    lint()
+      .files(
+        jsonClassStub,
+        jsonInflaterStub,
+        typeLabelStub,
+        defaultObjectStub,
+        kotlin(
+          """
+        package test
+
+        import com.squareup.moshi.JsonClass
+        import slack.commons.json.JsonInflater
+        import dev.zacsweers.moshix.sealed.annotations.TypeLabel
+        import dev.zacsweers.moshix.sealed.annotations.DefaultObject
+
+        sealed interface Animal {
+            @TypeLabel("dog")
+            @JsonClass(generateAdapter = true)
+            data class Dog(val name: String) : Animal
+
+            @TypeLabel("cat")
+            @JsonClass(generateAdapter = true)
+            data class Cat(val age: Int) : Animal
+
+            @DefaultObject
+            object Default : Animal
+        }
+
+        fun useJsonInflater(jsonInflater: JsonInflater) {
+            val model = jsonInflater.inflate("{}", Animal::class.java)
+            val json = jsonInflater.deflate(model, Animal::class.java)
+        }
+      """
+        ),
+      )
+      .run()
+      .expect(
+        """
+            src/test/Animal.kt:23: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
+                        val model = jsonInflater.inflate("{}", Animal::class.java)
+                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            src/test/Animal.kt:24: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
+                        val json = jsonInflater.deflate(model, Animal::class.java)
+                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             2 errors
       """
       )


### PR DESCRIPTION
###  Summary

This PR updates `JsonInflaterMoshiCompatibilityDetector` to accept sealed interfaces as Moshi-compatible if they're annotated with `JsonClass` or `AdaptedBy`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
