### PR TITLE
Allow primitives in collections to be Moshi-compatible

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -152,7 +152,6 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
   private fun isInstantiable(psiClass: PsiClass): Boolean {
     return !psiClass.isInterface &&
       !psiClass.hasModifierProperty(PsiModifier.ABSTRACT) &&
-      !psiClass.isEnum &&
       psiClass.hasModifierProperty(PsiModifier.PUBLIC)
   }
 

--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -157,17 +157,18 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
 
   private fun isPrimitiveType(psiClass: PsiClass): Boolean {
     val qualifiedName = psiClass.qualifiedName ?: return false
-    return qualifiedName in listOf(
-      FQCN_JAVA_STRING,
-      FQCN_JAVA_BOOLEAN,
-      FQCN_JAVA_BYTE,
-      FQCN_JAVA_CHARACTER,
-      FQCN_JAVA_SHORT,
-      FQCN_JAVA_INTEGER,
-      FQCN_JAVA_LONG,
-      FQCN_JAVA_FLOAT,
-      FQCN_JAVA_DOUBLE
-    )
+    return qualifiedName in
+      listOf(
+        FQCN_JAVA_STRING,
+        FQCN_JAVA_BOOLEAN,
+        FQCN_JAVA_BYTE,
+        FQCN_JAVA_CHARACTER,
+        FQCN_JAVA_SHORT,
+        FQCN_JAVA_INTEGER,
+        FQCN_JAVA_LONG,
+        FQCN_JAVA_FLOAT,
+        FQCN_JAVA_DOUBLE,
+      )
   }
 
   private fun isAbstractOrNonPublicClass(psiClass: PsiClass): Boolean {

--- a/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/JsonInflaterMoshiCompatibilityDetector.kt
@@ -139,6 +139,8 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
   }
 
   private fun isMoshiCompatible(psiClass: PsiClass): Boolean {
+    if (isPrimitiveType(psiClass)) return true
+
     if (isCollectionType(psiClass)) return true
 
     if (isAbstractOrNonPublicClass(psiClass)) return false
@@ -151,6 +153,21 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
   private fun isCollectionType(psiClass: PsiClass): Boolean {
     val qualifiedName = psiClass.qualifiedName ?: return false
     return qualifiedName in listOf(FQCN_LIST, FQCN_SET, FQCN_MAP, FQCN_COLLECTION)
+  }
+
+  private fun isPrimitiveType(psiClass: PsiClass): Boolean {
+    val qualifiedName = psiClass.qualifiedName ?: return false
+    return qualifiedName in listOf(
+      FQCN_JAVA_STRING,
+      FQCN_JAVA_BOOLEAN,
+      FQCN_JAVA_BYTE,
+      FQCN_JAVA_CHARACTER,
+      FQCN_JAVA_SHORT,
+      FQCN_JAVA_INTEGER,
+      FQCN_JAVA_LONG,
+      FQCN_JAVA_FLOAT,
+      FQCN_JAVA_DOUBLE
+    )
   }
 
   private fun isAbstractOrNonPublicClass(psiClass: PsiClass): Boolean {
@@ -176,6 +193,14 @@ class JsonInflaterMoshiCompatibilityDetector : Detector(), SourceCodeScanner {
     // Fully qualified class names for relevant annotations and types
     private const val FQCN_JSON_INFLATER = "slack.commons.json.JsonInflater"
     private const val FQCN_JAVA_STRING = "java.lang.String"
+    private const val FQCN_JAVA_BOOLEAN = "java.lang.Boolean"
+    private const val FQCN_JAVA_BYTE = "java.lang.Byte"
+    private const val FQCN_JAVA_CHARACTER = "java.lang.Character"
+    private const val FQCN_JAVA_SHORT = "java.lang.Short"
+    private const val FQCN_JAVA_INTEGER = "java.lang.Integer"
+    private const val FQCN_JAVA_LONG = "java.lang.Long"
+    private const val FQCN_JAVA_FLOAT = "java.lang.Float"
+    private const val FQCN_JAVA_DOUBLE = "java.lang.Double"
     private const val FQCN_LIST = "java.util.List"
     private const val FQCN_SET = "java.util.Set"
     private const val FQCN_MAP = "java.util.Map"

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -279,16 +279,16 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
       .expectClean()
   }
 
-    @Test
-    fun testValidMapOfPrimitivers() {
-        lint()
-            .files(
-                jsonClassStub,
-                jsonInflaterStub,
-                adaptedByStub,
-                parameterizedTypeStub,
-                kotlin(
-                    """
+  @Test
+  fun testValidMapOfPrimitivers() {
+    lint()
+      .files(
+        jsonClassStub,
+        jsonInflaterStub,
+        adaptedByStub,
+        parameterizedTypeStub,
+        kotlin(
+          """
         package test
 
         import com.squareup.moshi.JsonClass
@@ -311,11 +311,11 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
             val json = jsonInflater.deflate(model, type)
         }
       """
-                ),
-            )
-            .run()
-            .expectClean()
-    }
+        ),
+      )
+      .run()
+      .expectClean()
+  }
 
   @Test
   fun testInvalidDataClassInList() {

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -280,7 +280,7 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
   }
 
   @Test
-  fun testValidMapOfPrimitivers() {
+  fun testValidMapOfPrimitives() {
     lint()
       .files(
         jsonClassStub,

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -36,21 +36,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
   """
     )
 
-  private val jsonStub =
-    java(
-      """
-    package com.squareup.moshi;
-
-    import java.lang.annotation.Retention;
-    import java.lang.annotation.RetentionPolicy;
-
-    @Retention(RetentionPolicy.RUNTIME)
-    public @interface Json {
-        String name();
-    }
-  """
-    )
-
   private val adaptedByStub =
     kotlin(
       """
@@ -114,7 +99,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         kotlin(
           """
@@ -146,7 +130,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         kotlin(
           """
@@ -180,7 +163,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         kotlin(
           """
@@ -212,7 +194,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         adaptedByStub,
         kotlin(
@@ -245,7 +226,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         adaptedByStub,
         parameterizedTypeStub,
@@ -284,7 +264,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         adaptedByStub,
         parameterizedTypeStub,
@@ -331,8 +310,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
   fun testMissingJsonClassAnnotation() {
     lint()
       .files(
-        jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         kotlin(
           """
@@ -372,7 +349,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         kotlin(
           """
@@ -404,7 +380,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
     lint()
       .files(
         jsonClassStub,
-        jsonStub,
         jsonInflaterStub,
         kotlin(
           """
@@ -440,4 +415,79 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
       """
       )
   }
+
+    @Test
+    fun testEnumClass() {
+        lint()
+            .files(
+                jsonClassStub,
+                jsonInflaterStub,
+                kotlin(
+                    """
+        package test
+
+        import com.squareup.moshi.JsonClass
+        import slack.commons.json.JsonInflater
+
+        @JsonClass(generateAdapter = false)
+        enum class ValidEnum {
+            UNKNOWN,
+            UP,
+            DOWN,
+            LEFT,
+            RIGHT
+        }
+
+        fun useJsonInflater(jsonInflater: JsonInflater) {
+            val model = jsonInflater.inflate("{}", ValidEnum::class.java)
+            val json = jsonInflater.deflate(model, ValidEnum::class.java)
+        }
+      """
+                ),
+            )
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun testEnumClassMissingJsonClassAnnotation() {
+        lint()
+            .files(
+                jsonClassStub,
+                jsonInflaterStub,
+                kotlin(
+                    """
+        package test
+
+        import com.squareup.moshi.JsonClass
+        import slack.commons.json.JsonInflater
+
+        enum class ValidEnum {
+            UNKNOWN,
+            UP,
+            DOWN,
+            LEFT,
+            RIGHT
+        }
+
+        fun useJsonInflater(jsonInflater: JsonInflater) {
+            val model = jsonInflater.inflate("{}", ValidEnum::class.java)
+            val json = jsonInflater.deflate(model, ValidEnum::class.java)
+        }
+      """
+                ),
+            )
+            .run()
+            .expect(
+                """
+            src/test/ValidEnum.kt:16: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
+                        val model = jsonInflater.inflate("{}", ValidEnum::class.java)
+                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            src/test/ValidEnum.kt:17: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
+                        val json = jsonInflater.deflate(model, ValidEnum::class.java)
+                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            2 errors
+      """
+            )
+    }
 }

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -279,6 +279,44 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
       .expectClean()
   }
 
+    @Test
+    fun testValidMapOfPrimitivers() {
+        lint()
+            .files(
+                jsonClassStub,
+                jsonInflaterStub,
+                adaptedByStub,
+                parameterizedTypeStub,
+                kotlin(
+                    """
+        package test
+
+        import com.squareup.moshi.JsonClass
+        import com.squareup.moshi.StubParameterizedType
+        import slack.commons.json.JsonInflater
+
+        @JsonClass(generateAdapter = true)
+        data class ValidModel(
+            val id: String,
+            val name: String,
+            val count: Int
+        )
+
+        fun useJsonInflater(jsonInflater: JsonInflater) {
+            val type = StubParameterizedType(
+                Map::class.java,
+                arrayOf(String::class.java, Int::class.java)
+            )
+            val model = jsonInflater.inflate<Map<String, String>>("{}", type)
+            val json = jsonInflater.deflate(model, type)
+        }
+      """
+                ),
+            )
+            .run()
+            .expectClean()
+    }
+
   @Test
   fun testInvalidDataClassInList() {
     lint()

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -416,14 +416,14 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
       )
   }
 
-    @Test
-    fun testEnumClass() {
-        lint()
-            .files(
-                jsonClassStub,
-                jsonInflaterStub,
-                kotlin(
-                    """
+  @Test
+  fun testEnumClass() {
+    lint()
+      .files(
+        jsonClassStub,
+        jsonInflaterStub,
+        kotlin(
+          """
         package test
 
         import com.squareup.moshi.JsonClass
@@ -443,20 +443,20 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
             val json = jsonInflater.deflate(model, ValidEnum::class.java)
         }
       """
-                ),
-            )
-            .run()
-            .expectClean()
-    }
+        ),
+      )
+      .run()
+      .expectClean()
+  }
 
-    @Test
-    fun testEnumClassMissingJsonClassAnnotation() {
-        lint()
-            .files(
-                jsonClassStub,
-                jsonInflaterStub,
-                kotlin(
-                    """
+  @Test
+  fun testEnumClassMissingJsonClassAnnotation() {
+    lint()
+      .files(
+        jsonClassStub,
+        jsonInflaterStub,
+        kotlin(
+          """
         package test
 
         import com.squareup.moshi.JsonClass
@@ -475,11 +475,11 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
             val json = jsonInflater.deflate(model, ValidEnum::class.java)
         }
       """
-                ),
-            )
-            .run()
-            .expect(
-                """
+        ),
+      )
+      .run()
+      .expect(
+        """
             src/test/ValidEnum.kt:16: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
                         val model = jsonInflater.inflate("{}", ValidEnum::class.java)
                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -488,6 +488,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             2 errors
       """
-            )
-    }
+      )
+  }
 }

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -295,13 +295,6 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
         import com.squareup.moshi.StubParameterizedType
         import slack.commons.json.JsonInflater
 
-        @JsonClass(generateAdapter = true)
-        data class ValidModel(
-            val id: String,
-            val name: String,
-            val count: Int
-        )
-
         fun useJsonInflater(jsonInflater: JsonInflater) {
             val type = StubParameterizedType(
                 Map::class.java,

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -307,7 +307,7 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
                 Map::class.java,
                 arrayOf(String::class.java, Int::class.java)
             )
-            val model = jsonInflater.inflate<Map<String, String>>("{}", type)
+            val model = jsonInflater.inflate<Map<String, Int>>("{}", type)
             val json = jsonInflater.deflate(model, type)
         }
       """

--- a/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/JsonInflaterMoshiCompatibilityDetectorTest.kt
@@ -89,6 +89,26 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
         .trimIndent()
     )
 
+  private val typeLabelStub =
+    kotlin(
+        """
+      package dev.zacsweers.moshix.sealed.annotations
+
+      annotation class TypeLabel(val label: String, val alternateLabels: Array<String> = [])
+    """
+      )
+      .indented()
+
+  private val defaultObjectStub =
+    kotlin(
+        """
+      package dev.zacsweers.moshix.sealed.annotations
+
+      annotation class DefaultObject
+    """
+      )
+      .indented()
+
   @Test
   fun testDocumentationExample() {
     testMissingJsonClassAnnotation()
@@ -486,6 +506,151 @@ class JsonInflaterMoshiCompatibilityDetectorTest : LintDetectorTest() {
             src/test/ValidEnum.kt:17: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
                         val json = jsonInflater.deflate(model, ValidEnum::class.java)
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            2 errors
+      """
+      )
+  }
+
+  @Test
+  fun testNonSealedInterface() {
+    lint()
+      .files(
+        jsonClassStub,
+        jsonInflaterStub,
+        typeLabelStub,
+        defaultObjectStub,
+        kotlin(
+          """
+        package test
+
+        import com.squareup.moshi.JsonClass
+        import slack.commons.json.JsonInflater
+        import dev.zacsweers.moshix.sealed.annotations.TypeLabel
+        import dev.zacsweers.moshix.sealed.annotations.DefaultObject
+
+        @JsonClass(generateAdapter = true, generator = "sealed:type")
+        interface Animal {
+            @TypeLabel("dog")
+            @JsonClass(generateAdapter = true)
+            data class Dog(val name: String) : Animal
+
+            @TypeLabel("cat")
+            @JsonClass(generateAdapter = true)
+            data class Cat(val age: Int) : Animal
+
+            @DefaultNull
+            object Default : Animal
+        }
+
+        fun useJsonInflater(jsonInflater: JsonInflater) {
+            val model = jsonInflater.inflate("{}", Animal::class.java)
+            val json = jsonInflater.deflate(model, Animal::class.java)
+        }
+      """
+        ),
+      )
+      .run()
+      .expect(
+        """
+            src/test/Animal.kt:24: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
+                        val model = jsonInflater.inflate("{}", Animal::class.java)
+                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            src/test/Animal.kt:25: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
+                        val json = jsonInflater.deflate(model, Animal::class.java)
+                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            2 errors
+      """
+      )
+  }
+
+  @Test
+  fun testSealedInterface() {
+    lint()
+      .files(
+        jsonClassStub,
+        jsonInflaterStub,
+        typeLabelStub,
+        defaultObjectStub,
+        kotlin(
+          """
+        package test
+
+        import com.squareup.moshi.JsonClass
+        import slack.commons.json.JsonInflater
+        import dev.zacsweers.moshix.sealed.annotations.TypeLabel
+        import dev.zacsweers.moshix.sealed.annotations.DefaultObject
+
+        @JsonClass(generateAdapter = true, generator = "sealed:type")
+        sealed interface Animal {
+            @TypeLabel("dog")
+            @JsonClass(generateAdapter = true)
+            data class Dog(val name: String) : Animal
+
+            @TypeLabel("cat")
+            @JsonClass(generateAdapter = true)
+            data class Cat(val age: Int) : Animal
+
+            @DefaultObject
+            object Default : Animal
+        }
+
+        fun useJsonInflater(jsonInflater: JsonInflater) {
+            val model = jsonInflater.inflate("{}", Animal::class.java)
+            val json = jsonInflater.deflate(model, Animal::class.java)
+        }
+      """
+        ),
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun testSealedInterfaceMissingJsonClassAnnotation() {
+    lint()
+      .files(
+        jsonClassStub,
+        jsonInflaterStub,
+        typeLabelStub,
+        defaultObjectStub,
+        kotlin(
+          """
+        package test
+
+        import com.squareup.moshi.JsonClass
+        import slack.commons.json.JsonInflater
+        import dev.zacsweers.moshix.sealed.annotations.TypeLabel
+        import dev.zacsweers.moshix.sealed.annotations.DefaultObject
+
+        sealed interface Animal {
+            @TypeLabel("dog")
+            @JsonClass(generateAdapter = true)
+            data class Dog(val name: String) : Animal
+
+            @TypeLabel("cat")
+            @JsonClass(generateAdapter = true)
+            data class Cat(val age: Int) : Animal
+
+            @DefaultObject
+            object Default : Animal
+        }
+
+        fun useJsonInflater(jsonInflater: JsonInflater) {
+            val model = jsonInflater.inflate("{}", Animal::class.java)
+            val json = jsonInflater.deflate(model, Animal::class.java)
+        }
+      """
+        ),
+      )
+      .run()
+      .expect(
+        """
+            src/test/Animal.kt:23: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
+                        val model = jsonInflater.inflate("{}", Animal::class.java)
+                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            src/test/Animal.kt:24: Error: Using JsonInflater.inflate/deflate with a Moshi-incompatible type. [JsonInflaterMoshiIncompatibleType]
+                        val json = jsonInflater.deflate(model, Animal::class.java)
+                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             2 errors
       """
       )


### PR DESCRIPTION
###  Summary

This PR updates `JsonInflaterMoshiCompatibilityDetector` to accept primitives in parameterized types as Moshi-compatible.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
