### PR TITLE
Add shared lint option infrastructure

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/util/IntLintOption.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/util/IntLintOption.kt
@@ -1,0 +1,15 @@
+// Copyright (C) 2025 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.util
+
+import com.android.tools.lint.client.api.Configuration
+import com.android.tools.lint.detector.api.IntOption
+
+open class IntLintOption(private val option: IntOption) : LintOption {
+  var value: Int = option.defaultValue
+    private set
+
+  override fun load(configuration: Configuration) {
+    value = option.getValue(configuration)
+  }
+}

--- a/slack-lint-checks/src/main/java/slack/lint/util/LintUtils.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/util/LintUtils.kt
@@ -390,3 +390,16 @@ internal val PsiMethod.returnsUnit
  */
 internal val PsiType?.isVoidOrUnit
   get() = this == PsiTypes.voidType() || this?.canonicalText == "kotlin.Unit"
+
+/**
+ * Returns true if this [UAnnotated] element has any annotation whose short name is in
+ * [annotationNames]. Matches on simple name to avoid requiring fully qualified annotations in
+ * config.
+ */
+internal fun UAnnotated.hasAnyAnnotation(annotationNames: Set<String>): Boolean {
+  if (annotationNames.isEmpty()) return false
+  return uAnnotations.any { annotation ->
+    val name = annotation.qualifiedName?.substringAfterLast('.') ?: return@any false
+    name in annotationNames
+  }
+}


### PR DESCRIPTION
# Change

First in a series replacing our detekt rules with configurable lint checks. To keep review sane, the work is split one detector per PR. This one lands the shared bits the detectors depend on, so it goes in first.

- `IntLintOption` — typed wrapper for `IntOption` lint config, mirroring the existing `StringSetLintOption`/`BooleanLintOption`
- `hasAnyAnnotation` — UAST helper to match an element's annotations by simple name (so config doesn't need fully-qualified names)

Nothing consumes these yet; the detector PRs follow and build on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)