### PR TITLE
Add CyclomaticComplexMethodDetector lint check

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/complexity/CyclomaticComplexMethodDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/complexity/CyclomaticComplexMethodDetector.kt
@@ -10,17 +10,24 @@ import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.JavaContext
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.StringOption
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
 import org.jetbrains.kotlin.psi.KtWhenEntry
+import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 import org.jetbrains.uast.UBinaryExpression
+import org.jetbrains.uast.UBreakExpression
+import org.jetbrains.uast.UCallExpression
 import org.jetbrains.uast.UCatchClause
+import org.jetbrains.uast.UContinueExpression
 import org.jetbrains.uast.UDoWhileExpression
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.UForEachExpression
-import org.jetbrains.uast.UForExpression
 import org.jetbrains.uast.UIfExpression
 import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.USwitchClauseExpression
@@ -31,6 +38,7 @@ import org.jetbrains.uast.visitor.AbstractUastVisitor
 import slack.lint.util.BooleanLintOption
 import slack.lint.util.IntLintOption
 import slack.lint.util.OptionLoadingDetector
+import slack.lint.util.StringSetLintOption
 import slack.lint.util.sourceImplementation
 
 class CyclomaticComplexMethodDetector(
@@ -38,8 +46,17 @@ class CyclomaticComplexMethodDetector(
   private val ignoreSingleWhenOption: BooleanLintOption = BooleanLintOption(IGNORE_SINGLE_WHEN),
   private val ignoreSimpleWhenEntriesOption: BooleanLintOption =
     BooleanLintOption(IGNORE_SIMPLE_WHEN_ENTRIES),
+  private val ignoreNestingFunctionsOption: BooleanLintOption =
+    BooleanLintOption(IGNORE_NESTING_FUNCTIONS),
+  private val nestingFunctionsOption: StringSetLintOption = StringSetLintOption(NESTING_FUNCTIONS),
 ) :
-  OptionLoadingDetector(thresholdOption, ignoreSingleWhenOption, ignoreSimpleWhenEntriesOption),
+  OptionLoadingDetector(
+    thresholdOption,
+    ignoreSingleWhenOption,
+    ignoreSimpleWhenEntriesOption,
+    ignoreNestingFunctionsOption,
+    nestingFunctionsOption,
+  ),
   SourceCodeScanner {
 
   override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(UMethod::class.java)
@@ -47,6 +64,8 @@ class CyclomaticComplexMethodDetector(
   override fun createUastHandler(context: JavaContext): UElementHandler {
     return object : UElementHandler() {
       override fun visitMethod(node: UMethod) {
+        // Methods inside an object literal are excluded from complexity.
+        if (node.sourcePsi?.getStrictParentOfType<KtObjectLiteralExpression>() != null) return
         val body = node.uastBody ?: return
         var complexity = 1
         var whenCount = 0
@@ -55,11 +74,6 @@ class CyclomaticComplexMethodDetector(
         body.accept(
           object : AbstractUastVisitor() {
             override fun visitIfExpression(node: UIfExpression): Boolean {
-              complexity++
-              return false
-            }
-
-            override fun visitForExpression(node: UForExpression): Boolean {
               complexity++
               return false
             }
@@ -97,6 +111,24 @@ class CyclomaticComplexMethodDetector(
 
             override fun visitCatchClause(node: UCatchClause): Boolean {
               complexity++
+              return false
+            }
+
+            override fun visitBreakExpression(node: UBreakExpression): Boolean {
+              complexity++
+              return false
+            }
+
+            override fun visitContinueExpression(node: UContinueExpression): Boolean {
+              complexity++
+              return false
+            }
+
+            override fun visitCallExpression(node: UCallExpression): Boolean {
+              // Nesting functions (e.g. `forEach`, `let`, `run`) introduce a nested control scope.
+              if (!ignoreNestingFunctionsOption.value && node.isNestingFunctionWithLambda()) {
+                complexity++
+              }
               return false
             }
 
@@ -143,6 +175,14 @@ class CyclomaticComplexMethodDetector(
     return (sourcePsi as? KtWhenEntry)?.expression is KtBlockExpression
   }
 
+  /** True if this is a call to a configured nesting function passing a lambda with a body. */
+  private fun UCallExpression.isNestingFunctionWithLambda(): Boolean {
+    val ktCall = sourcePsi as? KtCallExpression ?: return false
+    if (ktCall.getCallNameExpression()?.text !in nestingFunctionsOption.value) return false
+    val lambda = ktCall.lambdaArguments.firstOrNull()?.getLambdaExpression()
+    return lambda?.bodyExpression != null
+  }
+
   companion object {
     private val THRESHOLD =
       IntOption("threshold", "Maximum cyclomatic complexity allowed per function.", 15)
@@ -161,6 +201,22 @@ class CyclomaticComplexMethodDetector(
         true,
       )
 
+    private val IGNORE_NESTING_FUNCTIONS =
+      BooleanOption(
+        "ignore-nesting-functions",
+        "If true, calls to nesting functions (e.g. run, let, forEach) don't add to complexity.",
+        false,
+      )
+
+    private val NESTING_FUNCTIONS =
+      StringOption(
+        "nesting-functions",
+        "A comma-separated list of function names that introduce a nested control-flow scope.",
+        "run,let,apply,with,also,use,forEach,isNotNull,ifNull",
+        "A comma-separated list of function names that introduce a nested control-flow scope. " +
+          "Calls to these with a lambda body add to a function's cyclomatic complexity.",
+      )
+
     val ISSUE =
       Issue.create(
           id = "CyclomaticComplexMethod",
@@ -173,6 +229,14 @@ class CyclomaticComplexMethodDetector(
           severity = Severity.WARNING,
           implementation = sourceImplementation<CyclomaticComplexMethodDetector>(),
         )
-        .setOptions(listOf(THRESHOLD, IGNORE_SINGLE_WHEN, IGNORE_SIMPLE_WHEN_ENTRIES))
+        .setOptions(
+          listOf(
+            THRESHOLD,
+            IGNORE_SINGLE_WHEN,
+            IGNORE_SIMPLE_WHEN_ENTRIES,
+            IGNORE_NESTING_FUNCTIONS,
+            NESTING_FUNCTIONS,
+          )
+        )
   }
 }

--- a/slack-lint-checks/src/main/java/slack/lint/complexity/CyclomaticComplexMethodDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/complexity/CyclomaticComplexMethodDetector.kt
@@ -1,0 +1,178 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.complexity
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.BooleanOption
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.IntOption
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtWhenEntry
+import org.jetbrains.uast.UBinaryExpression
+import org.jetbrains.uast.UCatchClause
+import org.jetbrains.uast.UDoWhileExpression
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.UForEachExpression
+import org.jetbrains.uast.UForExpression
+import org.jetbrains.uast.UIfExpression
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.USwitchClauseExpression
+import org.jetbrains.uast.USwitchExpression
+import org.jetbrains.uast.UWhileExpression
+import org.jetbrains.uast.UastBinaryOperator
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+import slack.lint.util.BooleanLintOption
+import slack.lint.util.IntLintOption
+import slack.lint.util.OptionLoadingDetector
+import slack.lint.util.sourceImplementation
+
+class CyclomaticComplexMethodDetector(
+  private val thresholdOption: IntLintOption = IntLintOption(THRESHOLD),
+  private val ignoreSingleWhenOption: BooleanLintOption = BooleanLintOption(IGNORE_SINGLE_WHEN),
+  private val ignoreSimpleWhenEntriesOption: BooleanLintOption =
+    BooleanLintOption(IGNORE_SIMPLE_WHEN_ENTRIES),
+) :
+  OptionLoadingDetector(thresholdOption, ignoreSingleWhenOption, ignoreSimpleWhenEntriesOption),
+  SourceCodeScanner {
+
+  override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(UMethod::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    return object : UElementHandler() {
+      override fun visitMethod(node: UMethod) {
+        val body = node.uastBody ?: return
+        var complexity = 1
+        var whenCount = 0
+        var whenEntries = 0
+
+        body.accept(
+          object : AbstractUastVisitor() {
+            override fun visitIfExpression(node: UIfExpression): Boolean {
+              complexity++
+              return false
+            }
+
+            override fun visitForExpression(node: UForExpression): Boolean {
+              complexity++
+              return false
+            }
+
+            override fun visitForEachExpression(node: UForEachExpression): Boolean {
+              complexity++
+              return false
+            }
+
+            override fun visitWhileExpression(node: UWhileExpression): Boolean {
+              complexity++
+              return false
+            }
+
+            override fun visitDoWhileExpression(node: UDoWhileExpression): Boolean {
+              complexity++
+              return false
+            }
+
+            override fun visitSwitchExpression(node: USwitchExpression): Boolean {
+              whenCount++
+              return false
+            }
+
+            override fun visitSwitchClauseExpression(node: USwitchClauseExpression): Boolean {
+              // The `else` branch has no case values and never adds complexity.
+              if (node.caseValues.isEmpty()) return false
+              // When ignoring simple when entries, only entries with a block body (e.g.
+              // `1 -> { ... }`) add complexity; single-expression entries are considered trivial.
+              if (ignoreSimpleWhenEntriesOption.value && !node.hasBlockBody()) return false
+              complexity++
+              whenEntries++
+              return false
+            }
+
+            override fun visitCatchClause(node: UCatchClause): Boolean {
+              complexity++
+              return false
+            }
+
+            override fun visitBinaryExpression(node: UBinaryExpression): Boolean {
+              if (
+                node.operator == UastBinaryOperator.LOGICAL_AND ||
+                  node.operator == UastBinaryOperator.LOGICAL_OR
+              ) {
+                complexity++
+              }
+              return false
+            }
+
+            override fun visitExpression(node: UExpression): Boolean {
+              // The elvis operator (`?:`) introduces a branch but UAST models it as a dedicated
+              // expression rather than a UBinaryExpression, so detect it via its source PSI.
+              val ktBinary = node.sourcePsi as? KtBinaryExpression
+              if (ktBinary?.operationToken == KtTokens.ELVIS) {
+                complexity++
+              }
+              return false
+            }
+          }
+        )
+
+        if (ignoreSingleWhenOption.value && whenCount == 1) {
+          complexity -= whenEntries
+        }
+
+        if (complexity > thresholdOption.value) {
+          context.report(
+            ISSUE,
+            node,
+            context.getNameLocation(node),
+            "Function has a cyclomatic complexity of $complexity, exceeding the limit of ${thresholdOption.value}.",
+          )
+        }
+      }
+    }
+  }
+
+  /** True if this when entry's body is a block (`-> { ... }`) rather than a single expression. */
+  private fun USwitchClauseExpression.hasBlockBody(): Boolean {
+    return (sourcePsi as? KtWhenEntry)?.expression is KtBlockExpression
+  }
+
+  companion object {
+    private val THRESHOLD =
+      IntOption("threshold", "Maximum cyclomatic complexity allowed per function.", 15)
+
+    private val IGNORE_SINGLE_WHEN =
+      BooleanOption(
+        "ignore-single-when-expression",
+        "If true, functions with a single when expression are not counted.",
+        true,
+      )
+
+    private val IGNORE_SIMPLE_WHEN_ENTRIES =
+      BooleanOption(
+        "ignore-simple-when-entries",
+        "If true, simple when entries (single line) don't add to complexity.",
+        true,
+      )
+
+    val ISSUE =
+      Issue.create(
+          id = "CyclomaticComplexMethod",
+          briefDescription = "Function has high cyclomatic complexity",
+          explanation =
+            "Functions with high cyclomatic complexity have too many decision points, " +
+              "making them hard to understand and test. Consider decomposing the function.",
+          category = Category.CORRECTNESS,
+          priority = 5,
+          severity = Severity.WARNING,
+          implementation = sourceImplementation<CyclomaticComplexMethodDetector>(),
+        )
+        .setOptions(listOf(THRESHOLD, IGNORE_SINGLE_WHEN, IGNORE_SIMPLE_WHEN_ENTRIES))
+  }
+}

--- a/slack-lint-checks/src/test/java/slack/lint/complexity/CyclomaticComplexMethodDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/complexity/CyclomaticComplexMethodDetectorTest.kt
@@ -1,0 +1,213 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.complexity
+
+import com.android.tools.lint.checks.infrastructure.TestMode
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+
+class CyclomaticComplexMethodDetectorTest : BaseSlackLintTest() {
+  override fun getDetector() = CyclomaticComplexMethodDetector()
+
+  override fun getIssues() = listOf(CyclomaticComplexMethodDetector.ISSUE)
+
+  // IF_TO_WHEN rewrites if/else chains into when expressions; because simple when entries are
+  // ignored by default (unlike if branches), the two forms intentionally yield different
+  // complexity, so the cross-mode consistency check does not apply.
+  override val skipTestModes =
+    arrayOf(TestMode.WHITESPACE, TestMode.SUPPRESSIBLE, TestMode.IF_TO_WHEN)
+
+  @Test
+  fun `clean - simple function`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example(x: Int): Int {
+            if (x > 0) return 1
+            return 0
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - too many decision points`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example(x: Int) {
+            if (x == 1) println("1")
+            if (x == 2) println("2")
+            if (x == 3) println("3")
+            if (x == 4) println("4")
+            if (x == 5) println("5")
+            if (x == 6) println("6")
+            if (x == 7) println("7")
+            if (x == 8) println("8")
+            if (x == 9) println("9")
+            if (x == 10) println("10")
+            if (x == 11) println("11")
+            if (x == 12) println("12")
+            if (x == 13) println("13")
+            if (x == 14) println("14")
+            if (x == 15) println("15")
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Function has a cyclomatic complexity of 16, exceeding the limit of 15")
+  }
+
+  @Test
+  fun `clean - higher threshold configured`() {
+    lint()
+      .configureOption("threshold", "20")
+      .files(
+        kotlin(
+            """
+          fun example(x: Int) {
+            if (x == 1) println("1")
+            if (x == 2) println("2")
+            if (x == 3) println("3")
+            if (x == 4) println("4")
+            if (x == 5) println("5")
+            if (x == 6) println("6")
+            if (x == 7) println("7")
+            if (x == 8) println("8")
+            if (x == 9) println("9")
+            if (x == 10) println("10")
+            if (x == 11) println("11")
+            if (x == 12) println("12")
+            if (x == 13) println("13")
+            if (x == 14) println("14")
+            if (x == 15) println("15")
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - simple when entries ignored by default`() {
+    // Two when expressions (so the single-when exemption does not apply) with only
+    // single-expression entries. By default these simple entries add no complexity.
+    lint()
+      .configureOption("threshold", "5")
+      .files(
+        kotlin(
+            """
+          fun example(x: Int, y: Int) {
+            when (x) {
+              1 -> println("a")
+              2 -> println("b")
+              3 -> println("c")
+              else -> println("d")
+            }
+            when (y) {
+              1 -> println("e")
+              2 -> println("f")
+              3 -> println("g")
+              else -> println("h")
+            }
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - simple when entries counted when option disabled`() {
+    lint()
+      .configureOption("threshold", "5")
+      .configureOption("ignore-simple-when-entries", "false")
+      .files(
+        kotlin(
+            """
+          fun example(x: Int, y: Int) {
+            when (x) {
+              1 -> println("a")
+              2 -> println("b")
+              3 -> println("c")
+              else -> println("d")
+            }
+            when (y) {
+              1 -> println("e")
+              2 -> println("f")
+              3 -> println("g")
+              else -> println("h")
+            }
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("exceeding the limit of 5")
+  }
+
+  @Test
+  fun `error - elvis operators add complexity`() {
+    lint()
+      .configureOption("threshold", "3")
+      .files(
+        kotlin(
+            """
+          fun example(a: Int?, b: Int?, c: Int?, d: Int?): Int {
+            val w = a ?: 0
+            val x = b ?: 0
+            val y = c ?: 0
+            val z = d ?: 0
+            return w + x + y + z
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("exceeding the limit of 3")
+  }
+
+  @Test
+  fun `error - block-bodied when entries still count`() {
+    // Block-bodied entries are not "simple" and add complexity even with the default option on.
+    lint()
+      .configureOption("threshold", "5")
+      .files(
+        kotlin(
+            """
+          fun example(x: Int, y: Int) {
+            when (x) {
+              1 -> { println("a") }
+              2 -> { println("b") }
+              3 -> { println("c") }
+              else -> { println("d") }
+            }
+            when (y) {
+              1 -> { println("e") }
+              2 -> { println("f") }
+              3 -> { println("g") }
+              else -> { println("h") }
+            }
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("exceeding the limit of 5")
+  }
+}

--- a/slack-lint-checks/src/test/java/slack/lint/complexity/CyclomaticComplexMethodDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/complexity/CyclomaticComplexMethodDetectorTest.kt
@@ -182,6 +182,175 @@ class CyclomaticComplexMethodDetectorTest : BaseSlackLintTest() {
   }
 
   @Test
+  fun `error - control flow constructs each add complexity`() {
+    lint()
+      .configureOption("threshold", "5")
+      .files(
+        kotlin(
+            """
+          fun example(items: List<Int>, n: Int): Int {
+            var sum = 0
+            for (i in items) {
+              sum += i
+            }
+            items.forEach { sum += it }
+            var i = 0
+            while (i < n) {
+              i++
+            }
+            do {
+              i--
+            } while (i > 0)
+            try {
+              sum += 1
+            } catch (e: Exception) {
+              sum += 2
+            }
+            return sum
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Function has a cyclomatic complexity of 6, exceeding the limit of 5")
+  }
+
+  @Test
+  fun `error - boolean operators each add complexity`() {
+    lint()
+      .configureOption("threshold", "4")
+      .files(
+        kotlin(
+            """
+          fun example(a: Boolean, b: Boolean, c: Boolean, d: Boolean): Boolean {
+            return (a && b) || (c && d) || a
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Function has a cyclomatic complexity of 5, exceeding the limit of 4")
+  }
+
+  @Test
+  fun `error - break and continue each add complexity`() {
+    lint()
+      .configureOption("threshold", "5")
+      .files(
+        kotlin(
+            """
+          fun example(items: List<Int>) {
+            for (i in items) {
+              if (i < 0) continue
+              if (i > 100) break
+              println(i)
+            }
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Function has a cyclomatic complexity of 6, exceeding the limit of 5")
+  }
+
+  @Test
+  fun `error - nesting function calls add complexity`() {
+    lint()
+      .configureOption("threshold", "3")
+      .files(
+        kotlin(
+            """
+          fun example(items: List<Int>, value: Int?) {
+            items.forEach { println(it) }
+            value?.let { println(it) }
+            run { println("done") }
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Function has a cyclomatic complexity of 4, exceeding the limit of 3")
+  }
+
+  @Test
+  fun `error - control flow inside a nesting function lambda still counts`() {
+    lint()
+      .configureOption("threshold", "2")
+      .files(
+        kotlin(
+            """
+          fun example(items: List<Int>) {
+            items.forEach {
+              if (it > 0) println(it)
+            }
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Function has a cyclomatic complexity of 3, exceeding the limit of 2")
+  }
+
+  @Test
+  fun `clean - object literal method is not reported on its own`() {
+    // A method declared inside an object literal is dispatched independently by lint but excluded
+    // from complexity, so it is never reported standalone even though its own body has enough
+    // decision points to exceed the threshold of 1.
+    lint()
+      .configureOption("threshold", "1")
+      .files(
+        kotlin(
+            """
+          fun interface Predicate {
+            fun test(x: Int): Boolean
+          }
+
+          fun makePredicate(): Predicate {
+            return object : Predicate {
+              override fun test(x: Int): Boolean {
+                if (x > 0) return true
+                if (x < -10) return true
+                return false
+              }
+            }
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      // The override is never reported standalone; only makePredicate is.
+      .expectContains("complexity of 3")
+      .expectContains("fun makePredicate")
+  }
+
+  @Test
+  fun `clean - nesting functions ignored when option disabled`() {
+    lint()
+      .configureOption("threshold", "3")
+      .configureOption("ignore-nesting-functions", "true")
+      .files(
+        kotlin(
+            """
+          fun example(items: List<Int>, value: Int?) {
+            items.forEach { println(it) }
+            value?.let { println(it) }
+            run { println("done") }
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
   fun `error - block-bodied when entries still count`() {
     // Block-bodied entries are not "simple" and add complexity even with the default option on.
     lint()


### PR DESCRIPTION
# Change

Part of the detekt → lint migration series. Replaces detekt's `CyclomaticComplexMethod` rule with a lint detector. Builds on the shared option infra from #481.

- Reports methods whose cyclomatic complexity exceeds the configured threshold
- `ignore-simple-when-entries` option implemented: simple (non block-body) `when` entries don't add complexity; block-bodied entries still count
- Counts elvis (`?:`) toward complexity, matching detekt. Elvis is a `KotlinUElvisExpression` (not a `UBinaryExpression`), so it's detected via `KtBinaryExpression.operationToken == KtTokens.ELVIS`

Reviewing locally, leaving in draft.

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>