### PR TITLE
Add LongMethodDetector lint check

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/complexity/LongMethodDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/complexity/LongMethodDetector.kt
@@ -1,0 +1,130 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.complexity
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.IntOption
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.kotlin.kdoc.psi.api.KDoc
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UMethod
+import slack.lint.util.IntLintOption
+import slack.lint.util.OptionLoadingDetector
+import slack.lint.util.sourceImplementation
+
+class LongMethodDetector(private val thresholdOption: IntLintOption = IntLintOption(THRESHOLD)) :
+  OptionLoadingDetector(thresholdOption), SourceCodeScanner {
+
+  override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(UMethod::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    return object : UElementHandler() {
+      override fun visitMethod(node: UMethod) {
+        val function = node.sourcePsi as? KtNamedFunction ?: return
+        val lineCount = countLines(function)
+        if (lineCount > thresholdOption.value) {
+          context.report(
+            ISSUE,
+            node,
+            context.getNameLocation(node),
+            "Function is too long ($lineCount lines), exceeding the limit of ${thresholdOption.value}.",
+          )
+        }
+      }
+    }
+  }
+
+  /**
+   * Counts the lines of code in [function]: distinct physical lines containing a non-whitespace,
+   * non-comment token. Top-level functions are measured by their body; nested functions are
+   * measured whole. The net line count of every nested function is subtracted so their lines aren't
+   * attributed to the enclosing function.
+   */
+  private fun countLines(function: KtNamedFunction): Int {
+    val body = function.bodyBlockExpression ?: function.bodyExpression ?: return 0
+    val fileText = function.containingFile?.text ?: return 0
+    val newlineOffsets = newlineOffsets(fileText)
+
+    val isNested = PsiTreeUtil.getParentOfType(function, KtNamedFunction::class.java) != null
+    val measured: PsiElement = if (isNested) function else body
+    return distinctCodeLines(measured, newlineOffsets) -
+      nestedFunctionLines(function, newlineOffsets)
+  }
+
+  /**
+   * Sum of the net line counts of every nested function, where a function's net count is its own
+   * whole-function line count minus the net counts of the functions nested within it.
+   */
+  private fun netLines(function: KtNamedFunction, newlineOffsets: IntArray): Int =
+    distinctCodeLines(function, newlineOffsets) - nestedFunctionLines(function, newlineOffsets)
+
+  private fun nestedFunctionLines(function: PsiElement, newlineOffsets: IntArray): Int =
+    PsiTreeUtil.findChildrenOfType(function, KtNamedFunction::class.java).sumOf {
+      netLines(it, newlineOffsets)
+    }
+
+  private fun distinctCodeLines(element: PsiElement, newlineOffsets: IntArray): Int {
+    val lines = HashSet<Int>()
+    collectCodeLines(element, newlineOffsets, lines)
+    return lines.size
+  }
+
+  private fun collectCodeLines(element: PsiElement, newlineOffsets: IntArray, lines: HashSet<Int>) {
+    // Skip whitespace and comment/KDoc subtrees entirely so they don't count toward length.
+    if (element is PsiWhiteSpace || element is PsiComment || element is KDoc) return
+    var child = element.firstChild
+    if (child == null) {
+      lines.add(lineIndex(element.textRange.startOffset, newlineOffsets))
+      return
+    }
+    while (child != null) {
+      collectCodeLines(child, newlineOffsets, lines)
+      child = child.nextSibling
+    }
+  }
+
+  /** Returns the 0-based line index for [offset] via binary search over [newlineOffsets]. */
+  private fun lineIndex(offset: Int, newlineOffsets: IntArray): Int {
+    var lo = 0
+    var hi = newlineOffsets.size
+    while (lo < hi) {
+      val mid = (lo + hi) ushr 1
+      if (newlineOffsets[mid] < offset) lo = mid + 1 else hi = mid
+    }
+    return lo
+  }
+
+  private fun newlineOffsets(text: String): IntArray {
+    val offsets = ArrayList<Int>()
+    text.forEachIndexed { index, c -> if (c == '\n') offsets.add(index) }
+    return offsets.toIntArray()
+  }
+
+  companion object {
+    private val THRESHOLD =
+      IntOption("threshold", "Maximum number of lines allowed in a function.", 120)
+
+    val ISSUE =
+      Issue.create(
+          id = "LongMethod",
+          briefDescription = "Function is too long",
+          explanation =
+            "Long functions are harder to understand, test, and maintain. " +
+              "Consider extracting parts of the function into smaller, well-named functions.",
+          category = Category.CORRECTNESS,
+          priority = 5,
+          severity = Severity.WARNING,
+          implementation = sourceImplementation<LongMethodDetector>(),
+        )
+        .setOptions(listOf(THRESHOLD))
+  }
+}

--- a/slack-lint-checks/src/main/java/slack/lint/complexity/LongMethodDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/complexity/LongMethodDetector.kt
@@ -11,6 +11,7 @@ import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
@@ -28,17 +29,30 @@ class LongMethodDetector(private val thresholdOption: IntLintOption = IntLintOpt
 
   override fun createUastHandler(context: JavaContext): UElementHandler {
     return object : UElementHandler() {
+      private var cachedFile: PsiFile? = null
+      private var cachedNewlineOffsets = IntArray(0)
+
       override fun visitMethod(node: UMethod) {
         val function = node.sourcePsi as? KtNamedFunction ?: return
-        val lineCount = countLines(function)
+        val file = function.containingFile ?: return
+        val lineCount = countLines(function, newlineOffsetsFor(file))
         if (lineCount > thresholdOption.value) {
           context.report(
             ISSUE,
             node,
             context.getNameLocation(node),
-            "Function is too long ($lineCount lines), exceeding the limit of ${thresholdOption.value}.",
+            "Function is too long ($lineCount lines), exceeding the limit of ${thresholdOption.value}",
           )
         }
+      }
+
+      // Cached so a file with many functions scans its text once, not once per function.
+      private fun newlineOffsetsFor(file: PsiFile): IntArray {
+        if (cachedFile !== file) {
+          cachedFile = file
+          cachedNewlineOffsets = newlineOffsets(file.text)
+        }
+        return cachedNewlineOffsets
       }
     }
   }
@@ -49,10 +63,8 @@ class LongMethodDetector(private val thresholdOption: IntLintOption = IntLintOpt
    * measured whole. The net line count of every nested function is subtracted so their lines aren't
    * attributed to the enclosing function.
    */
-  private fun countLines(function: KtNamedFunction): Int {
+  private fun countLines(function: KtNamedFunction, newlineOffsets: IntArray): Int {
     val body = function.bodyBlockExpression ?: function.bodyExpression ?: return 0
-    val fileText = function.containingFile?.text ?: return 0
-    val newlineOffsets = newlineOffsets(fileText)
 
     val isNested = PsiTreeUtil.getParentOfType(function, KtNamedFunction::class.java) != null
     val measured: PsiElement = if (isNested) function else body
@@ -78,17 +90,24 @@ class LongMethodDetector(private val thresholdOption: IntLintOption = IntLintOpt
     return lines.size
   }
 
-  private fun collectCodeLines(element: PsiElement, newlineOffsets: IntArray, lines: HashSet<Int>) {
-    // Skip whitespace and comment/KDoc subtrees entirely so they don't count toward length.
-    if (element is PsiWhiteSpace || element is PsiComment || element is KDoc) return
-    var child = element.firstChild
-    if (child == null) {
-      lines.add(lineIndex(element.textRange.startOffset, newlineOffsets))
-      return
-    }
-    while (child != null) {
-      collectCodeLines(child, newlineOffsets, lines)
-      child = child.nextSibling
+  // Iterative so deeply nested expressions can't overflow the stack. Order doesn't matter because
+  // the caller collects line indices into a set.
+  private fun collectCodeLines(root: PsiElement, newlineOffsets: IntArray, lines: HashSet<Int>) {
+    val stack = ArrayDeque<PsiElement>()
+    stack.addLast(root)
+    while (stack.isNotEmpty()) {
+      val element = stack.removeLast()
+      // Skip whitespace and comment/KDoc subtrees entirely so they don't count toward length.
+      if (element is PsiWhiteSpace || element is PsiComment || element is KDoc) continue
+      var child = element.firstChild
+      if (child == null) {
+        lines.add(lineIndex(element.textRange.startOffset, newlineOffsets))
+        continue
+      }
+      while (child != null) {
+        stack.addLast(child)
+        child = child.nextSibling
+      }
     }
   }
 

--- a/slack-lint-checks/src/test/java/slack/lint/complexity/LongMethodDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/complexity/LongMethodDetectorTest.kt
@@ -1,0 +1,171 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.complexity
+
+import com.android.tools.lint.checks.infrastructure.TestMode
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+
+class LongMethodDetectorTest : BaseSlackLintTest() {
+  override fun getDetector() = LongMethodDetector()
+
+  override fun getIssues() = listOf(LongMethodDetector.ISSUE)
+
+  override val skipTestModes = arrayOf(TestMode.WHITESPACE, TestMode.SUPPRESSIBLE)
+
+  @Test
+  fun `clean - short function under default threshold`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            println("1")
+            println("2")
+            println("3")
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - function body exceeds configured threshold`() {
+    lint()
+      .configureOption("threshold", "3")
+      .files(
+        kotlin(
+            """
+          fun example() {
+            println("1")
+            println("2")
+            println("3")
+            println("4")
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      // Body spans 6 distinct code lines: the `{`, four println statements, and the `}`.
+      .expectContains("Function is too long (6 lines), exceeding the limit of 3")
+  }
+
+  @Test
+  fun `clean - long body allowed when threshold raised`() {
+    lint()
+      .configureOption("threshold", "10")
+      .files(
+        kotlin(
+            """
+          fun example() {
+            println("1")
+            println("2")
+            println("3")
+            println("4")
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - blank lines and comments are not counted`() {
+    // Body has 6 physical lines between braces but only 4 lines carry code tokens
+    // (`{`, two printlns, `}`). A raw newline count would flag this; counting code lines does not.
+    lint()
+      .configureOption("threshold", "4")
+      .files(
+        kotlin(
+            """
+          fun example() {
+            // a comment
+            println("1")
+
+            println("2")
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - nested function lines are subtracted from the enclosing function`() {
+    // outer's body spans 8 code lines, but inner's 4 lines are subtracted, leaving 4.
+    lint()
+      .configureOption("threshold", "5")
+      .files(
+        kotlin(
+            """
+          fun outer() {
+            println("a")
+            fun inner() {
+              println("b")
+              println("c")
+            }
+            println("d")
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - deeply nested function lines are subtracted at every level`() {
+    // outer's body spans 11 code lines; subtracting the nested functions leaves 4. A broken
+    // subtraction (e.g. counting the whole body) would flag this at threshold 5.
+    lint()
+      .configureOption("threshold", "5")
+      .files(
+        kotlin(
+            """
+          fun outer() {
+            println("a")
+            fun middle() {
+              println("b")
+              fun inner() {
+                println("c")
+              }
+              println("d")
+            }
+            println("e")
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - expression body functions are measured`() {
+    lint()
+      .configureOption("threshold", "2")
+      .files(
+        kotlin(
+            """
+          fun example() =
+            listOf(1, 2, 3)
+              .map { it * 2 }
+              .filter { it > 2 }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("exceeding the limit of 2")
+  }
+}


### PR DESCRIPTION
# Change

Adds the `LongMethod` lint check, which flags functions whose body is too long. Default threshold is 120 lines, configurable via the `threshold` option.

Length is measured as distinct physical lines containing a non-whitespace, non-comment token, so blank lines and comment/KDoc lines don't count. Top-level functions are measured by their body, nested functions whole, and every nested function's net line count is subtracted so its lines aren't attributed to the enclosing function.

