### PR TITLE
Add LongParameterListDetector lint check

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/complexity/LongParameterListDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/complexity/LongParameterListDetector.kt
@@ -1,0 +1,192 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.complexity
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.BooleanOption
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.IntOption
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Location
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.StringOption
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtConstructor
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtModifierListOwner
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UMethod
+import slack.lint.util.BooleanLintOption
+import slack.lint.util.IntLintOption
+import slack.lint.util.OptionLoadingDetector
+import slack.lint.util.StringSetLintOption
+import slack.lint.util.hasAnyAnnotation
+import slack.lint.util.sourceImplementation
+
+class LongParameterListDetector(
+  private val functionThresholdOption: IntLintOption = IntLintOption(FUNCTION_THRESHOLD),
+  private val constructorThresholdOption: IntLintOption = IntLintOption(CONSTRUCTOR_THRESHOLD),
+  private val ignoreDataClassesOption: BooleanLintOption = BooleanLintOption(IGNORE_DATA_CLASSES),
+  private val ignoreAnnotatedOption: StringSetLintOption = StringSetLintOption(IGNORE_ANNOTATED),
+) :
+  OptionLoadingDetector(
+    functionThresholdOption,
+    constructorThresholdOption,
+    ignoreDataClassesOption,
+    ignoreAnnotatedOption,
+  ),
+  SourceCodeScanner {
+
+  override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(UMethod::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    return object : UElementHandler() {
+      override fun visitMethod(node: UMethod) {
+        val source = node.sourcePsi
+        val isConstructor =
+          source is KtConstructor<*> || (source is KtClassOrObject && node.isConstructor)
+        if (isConstructor) {
+          if (!ignoresOwningDataClass(source)) {
+            report(
+              node.hasAnyAnnotation(ignoreAnnotatedOption.value),
+              source,
+              context.getNameLocation(node),
+              isConstructor = true,
+            )
+          }
+          return
+        }
+        if (source !is KtNamedFunction) return
+        report(
+          node.hasAnyAnnotation(ignoreAnnotatedOption.value),
+          source,
+          context.getNameLocation(node),
+          isConstructor = false,
+        )
+
+        // Lint never visits local functions, so check them from the enclosing declaration. They
+        // have no light-class method, so annotations and location come from the source instead.
+        reportLocalFunctions(source)
+      }
+
+      /**
+       * Reports local functions declared directly in [scope], recursing into each one. Stops at any
+       * declaration lint visits on its own, so a class member nested in here isn't reported twice.
+       */
+      private fun reportLocalFunctions(scope: KtElement) {
+        scope.children.forEach { child ->
+          when {
+            child is KtNamedFunction && child.isLocal -> {
+              report(
+                child.hasAnyIgnoredAnnotation(),
+                child,
+                context.getNameLocation(child),
+                isConstructor = false,
+              )
+              reportLocalFunctions(child)
+            }
+            child is KtClassOrObject -> Unit
+            child is KtElement -> reportLocalFunctions(child)
+          }
+        }
+      }
+
+      private fun report(
+        ignoredByAnnotation: Boolean,
+        source: PsiElement?,
+        location: Location,
+        isConstructor: Boolean,
+      ) {
+        if (ignoredByAnnotation) return
+        if ((source as? KtModifierListOwner)?.hasModifier(KtTokens.OVERRIDE_KEYWORD) == true) return
+
+        val threshold =
+          if (isConstructor) constructorThresholdOption.value else functionThresholdOption.value
+        // Count declared value parameters, not UAST parameters: the latter also includes the
+        // extension receiver and a suspend function's continuation.
+        val paramCount = valueParameterCount(source) ?: return
+        if (paramCount >= threshold) {
+          val subject = if (isConstructor) "Constructor" else "Function"
+          context.report(
+            ISSUE,
+            location,
+            "$subject has $paramCount parameters, the threshold is $threshold",
+          )
+        }
+      }
+
+      private fun KtNamedFunction.hasAnyIgnoredAnnotation(): Boolean {
+        val ignored = ignoreAnnotatedOption.value
+        if (ignored.isEmpty()) return false
+        return annotationEntries.any {
+          it.shortName?.asString() in ignored ||
+            it.typeReference?.text?.substringAfterLast('.') in ignored
+        }
+      }
+
+      private fun valueParameterCount(source: PsiElement?): Int? =
+        when (source) {
+          is KtFunction -> source.valueParameterList?.parameters?.size
+          is KtClassOrObject -> source.primaryConstructor?.valueParameters?.size
+          else -> null
+        }
+
+      private fun ignoresOwningDataClass(source: PsiElement?): Boolean {
+        if (!ignoreDataClassesOption.value) return false
+        val owner =
+          when (source) {
+            is KtConstructor<*> -> source.getContainingClassOrObject()
+            is KtClassOrObject -> source
+            else -> null
+          }
+        return (owner as? KtClass)?.hasModifier(KtTokens.DATA_KEYWORD) == true
+      }
+    }
+  }
+
+  companion object {
+    internal val FUNCTION_THRESHOLD =
+      IntOption("function-threshold", "Number of function parameters required to report.", 6)
+
+    internal val CONSTRUCTOR_THRESHOLD =
+      IntOption("constructor-threshold", "Number of constructor parameters required to report.", 7)
+
+    internal val IGNORE_DATA_CLASSES =
+      BooleanOption(
+        "ignore-data-classes",
+        "Ignore long constructor parameter lists on data classes.",
+        true,
+      )
+
+    internal val IGNORE_ANNOTATED =
+      StringOption(
+        "ignore-annotated",
+        "Comma-separated list of annotation simple names to ignore.",
+        "Inject,Provides,AssistedInject,Composable",
+        "Functions annotated with these annotations are excluded from this check.",
+      )
+
+    val ISSUE =
+      Issue.create(
+          id = "LongParameterList",
+          briefDescription = "Function has too many parameters",
+          explanation =
+            "Functions with many parameters are hard to call correctly and suggest " +
+              "the function is doing too much. Consider using a data class or builder pattern.",
+          category = Category.CORRECTNESS,
+          priority = 5,
+          severity = Severity.WARNING,
+          implementation = sourceImplementation<LongParameterListDetector>(),
+        )
+        .setOptions(
+          listOf(FUNCTION_THRESHOLD, CONSTRUCTOR_THRESHOLD, IGNORE_DATA_CLASSES, IGNORE_ANNOTATED)
+        )
+  }
+}

--- a/slack-lint-checks/src/main/java/slack/lint/util/LintUtils.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/util/LintUtils.kt
@@ -81,6 +81,19 @@ internal fun PsiClass.implements(
 }
 
 /**
+ * Returns true if this [UAnnotated] element has any annotation whose short name is in
+ * [annotationNames]. Matches on simple name to avoid requiring fully qualified annotations in
+ * config.
+ */
+internal fun UAnnotated.hasAnyAnnotation(annotationNames: Set<String>): Boolean {
+  if (annotationNames.isEmpty()) return false
+  return uAnnotations.any { annotation ->
+    val name = annotation.qualifiedName?.substringAfterLast('.') ?: return@any false
+    name in annotationNames
+  }
+}
+
+/**
  * Finds an annotation with the given [fqcn] on this element, accounting for Kotlin 2.2+ behavior.
  *
  * As of Kotlin 2.2, an annotation written with no explicit use-site target on a property or

--- a/slack-lint-checks/src/test/java/slack/lint/complexity/LongParameterListDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/complexity/LongParameterListDetectorTest.kt
@@ -1,0 +1,268 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.complexity
+
+import com.android.tools.lint.checks.infrastructure.TestMode
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+
+class LongParameterListDetectorTest : BaseSlackLintTest() {
+  override fun getDetector() = LongParameterListDetector()
+
+  override fun getIssues() = listOf(LongParameterListDetector.ISSUE)
+
+  override val skipTestModes =
+    arrayOf(TestMode.WHITESPACE, TestMode.SUPPRESSIBLE, TestMode.JVM_OVERLOADS)
+
+  @Test
+  fun `clean - function with acceptable parameters`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example(a: Int, b: Int, c: Int, d: Int, e: Int) {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - function at the threshold`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Function has 6 parameters, the threshold is 6")
+  }
+
+  @Test
+  fun `clean - ignoreAnnotated function`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          annotation class Inject
+
+          @Inject
+          fun example(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int) {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - higher threshold configured`() {
+    lint()
+      .configureOption(LongParameterListDetector.FUNCTION_THRESHOLD, 10)
+      .files(
+        kotlin(
+            """
+          fun example(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int) {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - extension receiver is not a value parameter`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun String.example(a: Int, b: Int, c: Int, d: Int, e: Int) {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - suspend continuation is not a value parameter`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          suspend fun example(a: Int, b: Int, c: Int, d: Int, e: Int) {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - local function is checked`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun outer() {
+            fun inner(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) {}
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectWarningCount(1)
+      .expectContains("Function has 6 parameters, the threshold is 6")
+  }
+
+  @Test
+  fun `error - function in anonymous object reported once`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          interface Foo
+
+          fun outer() {
+            val obj = object : Foo {
+              fun helper(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) {}
+            }
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectWarningCount(1)
+  }
+
+  @Test
+  fun `error - constructor uses its own threshold`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          class Example(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int)
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Constructor has 7 parameters, the threshold is 7")
+  }
+
+  @Test
+  fun `clean - constructor below its own threshold`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          class Example(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int)
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - data class constructor is exempt`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          data class Example(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int)
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - override function is exempt`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          open class Base {
+            open fun example(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int) {}
+          }
+
+          class Impl : Base() {
+            override fun example(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int) {}
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectWarningCount(1)
+      .expectContains("Base.kt:2")
+  }
+
+  @Test
+  fun `error - data class flagged when ignoreDataClasses disabled`() {
+    lint()
+      .configureOption(LongParameterListDetector.IGNORE_DATA_CLASSES, false)
+      .files(
+        kotlin(
+            """
+          data class Example(val a: Int, val b: Int, val c: Int, val d: Int, val e: Int, val f: Int, val g: Int)
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Constructor has 7 parameters, the threshold is 7")
+  }
+
+  @Test
+  fun `clean - ignoreAnnotated constructor`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          annotation class Inject
+
+          class Example @Inject constructor(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int)
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - custom ignoreAnnotated configured`() {
+    lint()
+      .configureOption(LongParameterListDetector.IGNORE_ANNOTATED, "MyCustomAnnotation")
+      .files(
+        kotlin(
+            """
+          annotation class MyCustomAnnotation
+
+          @MyCustomAnnotation
+          fun example(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int) {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+}


### PR DESCRIPTION
# Change

Adds `LongParameterListDetector`, which reports functions and constructors that take too many parameters.

Behavior:
- Functions report at 6+ parameters, constructors at 7+. Both configurable via `function-threshold` and `constructor-threshold`
- Data class constructors are exempt, controlled by `ignore-data-classes`
- `override` functions are skipped, since the signature is fixed by the supertype
- Functions annotated with `Inject`, `Provides`, `AssistedInject`, or `Composable` are skipped, configurable via `ignore-annotated`. Matched on simple name so config can use either the qualified or unqualified form
- Only declared value parameters count. `uastParameters` also includes the extension receiver and a suspend function's continuation, so `fun String.f(a, b, c, d, e)` is 5, not 6

Also restores `hasAnyAnnotation` to `LintUtils.kt` for the `ignore-annotated` lookup. `findAnnotationCompat` matches on FQCN only, which can't support the unqualified names in our config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)