### PR TITLE
Add TooManyFunctionsDetector lint check

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/complexity/TooManyFunctionsDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/complexity/TooManyFunctionsDetector.kt
@@ -1,0 +1,151 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.complexity
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.IntOption
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Location
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.StringOption
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UFile
+import slack.lint.util.IntLintOption
+import slack.lint.util.OptionLoadingDetector
+import slack.lint.util.StringSetLintOption
+import slack.lint.util.hasAnyAnnotation
+import slack.lint.util.sourceImplementation
+
+class TooManyFunctionsDetector(
+  private val inFilesOption: IntLintOption = IntLintOption(THRESHOLD_IN_FILES),
+  private val inClassesOption: IntLintOption = IntLintOption(THRESHOLD_IN_CLASSES),
+  private val inInterfacesOption: IntLintOption = IntLintOption(THRESHOLD_IN_INTERFACES),
+  private val inObjectsOption: IntLintOption = IntLintOption(THRESHOLD_IN_OBJECTS),
+  private val inEnumsOption: IntLintOption = IntLintOption(THRESHOLD_IN_ENUMS),
+  private val ignoreAnnotatedOption: StringSetLintOption = StringSetLintOption(IGNORE_ANNOTATED),
+) :
+  OptionLoadingDetector(
+    inFilesOption,
+    inClassesOption,
+    inInterfacesOption,
+    inObjectsOption,
+    inEnumsOption,
+    ignoreAnnotatedOption,
+  ),
+  SourceCodeScanner {
+
+  override fun getApplicableUastTypes(): List<Class<out UElement>> =
+    listOf(UClass::class.java, UFile::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    return object : UElementHandler() {
+      override fun visitClass(node: UClass) {
+        val declaration = node.sourcePsi as? KtClassOrObject ?: return
+        if (node.hasAnyAnnotation(ignoreAnnotatedOption.value)) return
+
+        val (subject, threshold) =
+          when {
+            declaration is KtClass && declaration.isInterface() ->
+              "Interface" to inInterfacesOption.value
+            declaration is KtClass && declaration.isEnum() -> "Enum class" to inEnumsOption.value
+            declaration is KtObjectDeclaration -> "Object" to inObjectsOption.value
+            else -> "Class" to inClassesOption.value
+          }
+
+        val count = declaration.functionCount()
+        if (count >= threshold) {
+          // An anonymous object has no name to report.
+          val subjectName = declaration.name?.let { "$subject `$it`" } ?: "Anonymous object"
+          context.report(
+            ISSUE,
+            context.getNameLocation(node),
+            "$subjectName has $count functions, the threshold is $threshold",
+          )
+        }
+      }
+
+      override fun visitFile(node: UFile) {
+        val file = node.sourcePsi as? KtFile ?: return
+        val threshold = inFilesOption.value
+        val count = file.declarations.count { it is KtNamedFunction }
+        if (count >= threshold) {
+          context.report(
+            ISSUE,
+            Location.create(context.file),
+            "File `${context.file.name}` has $count top-level functions, the threshold is $threshold",
+          )
+        }
+      }
+
+      // Only functions declared directly in the body count; a nested class's own functions are
+      // reported against that class instead.
+      private fun KtClassOrObject.functionCount(): Int =
+        body?.declarations?.count { it is KtNamedFunction } ?: 0
+    }
+  }
+
+  companion object {
+    internal val THRESHOLD_IN_FILES =
+      IntOption("threshold-in-files", "Number of top-level functions required to report.", 11)
+
+    internal val THRESHOLD_IN_CLASSES =
+      IntOption("threshold-in-classes", "Number of functions in a class required to report.", 11)
+
+    internal val THRESHOLD_IN_INTERFACES =
+      IntOption(
+        "threshold-in-interfaces",
+        "Number of functions in an interface required to report.",
+        11,
+      )
+
+    internal val THRESHOLD_IN_OBJECTS =
+      IntOption("threshold-in-objects", "Number of functions in an object required to report.", 11)
+
+    internal val THRESHOLD_IN_ENUMS =
+      IntOption(
+        "threshold-in-enums",
+        "Number of functions in an enum class required to report.",
+        11,
+      )
+
+    internal val IGNORE_ANNOTATED =
+      StringOption(
+        "ignore-annotated",
+        "Comma-separated list of annotation simple names to ignore.",
+        "Module",
+        "Classes annotated with these annotations are excluded from this check.",
+      )
+
+    val ISSUE =
+      Issue.create(
+          id = "TooManyFunctions",
+          briefDescription = "Class has too many functions",
+          explanation =
+            "Classes with too many functions are likely doing too much. " +
+              "Consider splitting responsibilities across multiple classes.",
+          category = Category.CORRECTNESS,
+          priority = 5,
+          severity = Severity.WARNING,
+          implementation = sourceImplementation<TooManyFunctionsDetector>(),
+        )
+        .setOptions(
+          listOf(
+            THRESHOLD_IN_FILES,
+            THRESHOLD_IN_CLASSES,
+            THRESHOLD_IN_INTERFACES,
+            THRESHOLD_IN_OBJECTS,
+            THRESHOLD_IN_ENUMS,
+            IGNORE_ANNOTATED,
+          )
+        )
+  }
+}

--- a/slack-lint-checks/src/test/java/slack/lint/complexity/TooManyFunctionsDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/complexity/TooManyFunctionsDetectorTest.kt
@@ -1,0 +1,256 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.complexity
+
+import com.android.tools.lint.checks.infrastructure.TestMode
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+
+class TooManyFunctionsDetectorTest : BaseSlackLintTest() {
+  override fun getDetector() = TooManyFunctionsDetector()
+
+  override fun getIssues() = listOf(TooManyFunctionsDetector.ISSUE)
+
+  override val skipTestModes =
+    arrayOf(TestMode.WHITESPACE, TestMode.SUPPRESSIBLE, TestMode.JVM_OVERLOADS)
+
+  private fun lintWithThresholds(threshold: Int = 1) =
+    lint()
+      .configureOption(TooManyFunctionsDetector.THRESHOLD_IN_FILES, threshold)
+      .configureOption(TooManyFunctionsDetector.THRESHOLD_IN_CLASSES, threshold)
+      .configureOption(TooManyFunctionsDetector.THRESHOLD_IN_INTERFACES, threshold)
+      .configureOption(TooManyFunctionsDetector.THRESHOLD_IN_OBJECTS, threshold)
+      .configureOption(TooManyFunctionsDetector.THRESHOLD_IN_ENUMS, threshold)
+
+  @Test
+  fun `error - function in class`() {
+    lintWithThresholds()
+      .files(
+        kotlin(
+            """
+          class Example {
+            fun a() = Unit
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Class Example has 1 functions, the threshold is 1")
+  }
+
+  @Test
+  fun `error - function in object`() {
+    lintWithThresholds()
+      .files(
+        kotlin(
+            """
+          object Example {
+            fun a() = Unit
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Object Example has 1 functions")
+  }
+
+  @Test
+  fun `error - function in interface`() {
+    lintWithThresholds()
+      .files(
+        kotlin(
+            """
+          interface Example {
+            fun a()
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Interface Example has 1 functions")
+  }
+
+  @Test
+  fun `error - function in enum`() {
+    lintWithThresholds()
+      .files(
+        kotlin(
+            """
+          enum class Example {
+            A;
+            fun a() = Unit
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Enum class Example has 1 functions")
+  }
+
+  @Test
+  fun `error - top level function in file`() {
+    lintWithThresholds()
+      .files(kotlin("fun f() = Unit").indented())
+      .run()
+      .expectContains("has 1 top-level functions, the threshold is 1")
+  }
+
+  @Test
+  fun `error - counts only top level functions in file`() {
+    lintWithThresholds(3)
+      .files(
+        kotlin(
+            """
+          fun f1() = Unit
+          class C
+          object O
+          fun f2() = Unit
+          interface I
+          enum class E
+          fun f3() = Unit
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("has 3 top-level functions")
+  }
+
+  @Test
+  fun `error - nested class counted separately`() {
+    lintWithThresholds()
+      .files(
+        kotlin(
+            """
+          class A {
+            class B {
+              fun a() = Unit
+            }
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectWarningCount(1)
+      .expectContains("Class B has 1 functions")
+  }
+
+  @Test
+  fun `error - anonymous object has no name to report`() {
+    lintWithThresholds()
+      .files(
+        kotlin(
+            """
+          interface Foo
+
+          val x = object : Foo {
+            fun a() = Unit
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Anonymous object has 1 functions, the threshold is 1")
+  }
+
+  @Test
+  fun `error - companion object counted separately`() {
+    lintWithThresholds()
+      .files(
+        kotlin(
+            """
+          class Example {
+            companion object {
+              fun a() = Unit
+            }
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectWarningCount(1)
+      .expectContains("Object Companion has 1 functions")
+  }
+
+  @Test
+  fun `clean - properties are not functions`() {
+    lintWithThresholds(3)
+      .files(
+        kotlin(
+            """
+          class Example {
+            val a: Int = 1
+            var b: Int = 2
+            fun one() = Unit
+            fun two() = Unit
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - data class synthetics are not functions`() {
+    lintWithThresholds(3)
+      .files(
+        kotlin(
+            """
+          data class Example(val a: Int, val b: Int) {
+            fun one() = Unit
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - ignoreAnnotated class`() {
+    lintWithThresholds()
+      .files(
+        kotlin(
+            """
+          annotation class Module
+
+          @Module
+          class Example {
+            fun a() = Unit
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - below threshold`() {
+    lintWithThresholds(3)
+      .files(
+        kotlin(
+            """
+          class Example {
+            fun a() = Unit
+            fun b() = Unit
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+}


### PR DESCRIPTION
# Change

Adds `TooManyFunctionsDetector`, which reports files, classes, interfaces, objects, and enum classes that declare too many functions. Each kind gets its own threshold, all defaulting to 11.

Two naming details worth knowing:

- an anonymous object has no name, so it's described as `Anonymous object` rather than interpolating `null` into the message
- a companion object is counted separately from its enclosing class, and reports as `Object Companion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)