### PR TITLE
Add SwallowedExceptionDetector lint check

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/exceptions/SwallowedExceptionDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/exceptions/SwallowedExceptionDetector.kt
@@ -1,0 +1,174 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.exceptions
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.StringOption
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCatchClause
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtThrowExpression
+import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
+import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForReceiverOrThis
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import org.jetbrains.uast.UCatchClause
+import org.jetbrains.uast.UElement
+import slack.lint.util.OptionLoadingDetector
+import slack.lint.util.StringSetLintOption
+import slack.lint.util.sourceImplementation
+
+class SwallowedExceptionDetector(
+  private val ignoredTypesOption: StringSetLintOption = StringSetLintOption(IGNORED_EXCEPTION_TYPES)
+) : OptionLoadingDetector(ignoredTypesOption), SourceCodeScanner {
+
+  override fun getApplicableUastTypes(): List<Class<out UElement>> =
+    listOf(UCatchClause::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    // Read as a whole string, not a set: a regex may legitimately contain a comma.
+    val allowedNameRegex =
+      Regex(
+        ALLOWED_EXCEPTION_NAME.getValue(context.configuration) ?: DEFAULT_ALLOWED_EXCEPTION_NAME
+      )
+    return object : UElementHandler() {
+      override fun visitCatchClause(node: UCatchClause) {
+        val catchClause = node.sourcePsi as? KtCatchClause ?: return
+        val catchParameter = catchClause.catchParameter ?: return
+        val ignoredTypes = ignoredTypesOption.value
+
+        val exceptionType = catchParameter.typeReference?.text
+        if (ignoredTypes.any { exceptionType?.contains(it, ignoreCase = true) == true }) return
+        if (allowedNameRegex.matches(catchParameter.nameIdentifier?.text.orEmpty())) return
+        if (!isSwallowedOrUnused(catchClause, ignoredTypes)) return
+
+        context.report(
+          ISSUE,
+          node,
+          context.getLocation(catchParameter),
+          "The caught exception is swallowed, so the original exception could be lost",
+        )
+      }
+    }
+  }
+
+  private fun isSwallowedOrUnused(catchClause: KtCatchClause, ignoredTypes: Set<String>): Boolean =
+    isUnused(catchClause, ignoredTypes) || isSwallowed(catchClause)
+
+  private fun isUnused(catchClause: KtCatchClause, ignoredTypes: Set<String>): Boolean {
+    val parameterName = catchClause.catchParameter?.name
+    val catchBody = catchClause.catchBody ?: return true
+    return !catchBody.anyDescendantOfType<KtNameReferenceExpression> {
+      it.text in ignoredTypes || it.text == parameterName
+    }
+  }
+
+  /** The exception is referenced, but only to pull values off it, so the original is dropped. */
+  private fun isSwallowed(catchClause: KtCatchClause): Boolean {
+    val parameterName = catchClause.catchParameter?.name
+    val catchBody = catchClause.catchBody ?: return false
+    return catchBody.anyDescendantOfType<KtThrowExpression> { throwExpression ->
+      val references = throwExpression.parameterReferences(parameterName, catchBody)
+      references.isNotEmpty() &&
+        references.all { it is KtDotQualifiedExpression && it.parent !is KtThrowExpression }
+    }
+  }
+
+  private fun KtThrowExpression.parameterReferences(
+    parameterName: String?,
+    catchBody: KtExpression,
+  ): List<KtExpression> {
+    val referencesInVariables = mutableMapOf<String, KtExpression>()
+    return thrownExpression
+      ?.collectDescendantsOfType<KtNameReferenceExpression>()
+      ?.mapNotNull { reference ->
+        val referenceText = reference.text
+        if (referenceText == parameterName) {
+          reference.getQualifiedExpressionForReceiverOrThis()
+        } else {
+          referencesInVariables[referenceText]
+            ?: reference.findReferenceInVariable(parameterName, referenceText, catchBody)?.also {
+              referencesInVariables[referenceText] = it
+            }
+        }
+      }
+      .orEmpty()
+  }
+
+  /** Follows `val message = e.message` so assigning to a local first is still a swallow. */
+  private fun KtExpression.findReferenceInVariable(
+    referenceName: String?,
+    variableName: String,
+    catchBody: KtExpression,
+  ): KtExpression? {
+    var block = getStrictParentOfType<KtBlockExpression>() ?: return null
+    while (true) {
+      val reference =
+        block
+          .findDescendantOfType<KtProperty> { it.name == variableName }
+          ?.let { property ->
+            val initializer = property.initializer
+            if (initializer is KtDotQualifiedExpression) {
+              initializer.takeIf { it.receiverExpression.text == referenceName }
+            } else {
+              initializer.takeIf { it?.text == referenceName }
+            }
+          }
+      if (reference != null) return reference
+      if (block === catchBody) return null
+      block = block.getStrictParentOfType<KtBlockExpression>() ?: return null
+    }
+  }
+
+  companion object {
+    private val DEFAULT_IGNORED_EXCEPTION_TYPES =
+      listOf(
+        "InterruptedException",
+        "MalformedURLException",
+        "NumberFormatException",
+        "ParseException",
+      )
+
+    private const val DEFAULT_ALLOWED_EXCEPTION_NAME = "_|(ignore|expected).*"
+
+    internal val IGNORED_EXCEPTION_TYPES =
+      StringOption(
+        "ignored-exception-types",
+        "Comma-separated list of exception simple names that may be caught without being used.",
+        DEFAULT_IGNORED_EXCEPTION_TYPES.joinToString(","),
+        "Catching these exceptions without using them is not flagged.",
+      )
+
+    internal val ALLOWED_EXCEPTION_NAME =
+      StringOption(
+        "allowed-exception-name-regex",
+        "Regex for catch parameter names that are exempt from this check.",
+        DEFAULT_ALLOWED_EXCEPTION_NAME,
+        "Catch blocks whose parameter name matches this pattern are allowed.",
+      )
+
+    val ISSUE =
+      Issue.create(
+          id = "SwallowedException",
+          briefDescription = "Caught exception is swallowed",
+          explanation =
+            "An exception is caught but neither used nor passed as the cause of a newly " +
+              "thrown exception. This loses the original stack trace and can hide bugs. " +
+              "Log the exception, rethrow it, or pass it as a cause.",
+          category = Category.CORRECTNESS,
+          priority = 6,
+          severity = Severity.WARNING,
+          implementation = sourceImplementation<SwallowedExceptionDetector>(),
+        )
+        .setOptions(listOf(IGNORED_EXCEPTION_TYPES, ALLOWED_EXCEPTION_NAME))
+  }
+}

--- a/slack-lint-checks/src/test/java/slack/lint/exceptions/SwallowedExceptionDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/exceptions/SwallowedExceptionDetectorTest.kt
@@ -1,0 +1,506 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.exceptions
+
+import com.android.tools.lint.checks.infrastructure.TestMode
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+
+class SwallowedExceptionDetectorTest : BaseSlackLintTest() {
+  override fun getDetector() = SwallowedExceptionDetector()
+
+  override fun getIssues() = listOf(SwallowedExceptionDetector.ISSUE)
+
+  // Exception types are matched by name, so an alias or extra parens hides them.
+  override val skipTestModes =
+    arrayOf(
+      TestMode.WHITESPACE,
+      TestMode.SUPPRESSIBLE,
+      TestMode.TYPE_ALIAS,
+      TestMode.PARENTHESIZED,
+    )
+
+  @Test
+  fun `clean - exception is logged`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: Exception) {
+              println(e.message)
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - exception is passed as the cause`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: Exception) {
+              throw IllegalArgumentException(e)
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - exception is passed as both message and cause`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: IllegalStateException) {
+              throw IllegalArgumentException(e.message, e)
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - exception used as a receiver and the result is thrown`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun Exception.transformException(): Exception = this
+
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: Exception) {
+              throw e.transformException()
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - exception is unused`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: Exception) {
+              println("failed")
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("The caught exception is swallowed")
+  }
+
+  @Test
+  fun `error - only the message is passed to a new exception`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: IllegalStateException) {
+              throw IllegalArgumentException(e.message)
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("The caught exception is swallowed")
+  }
+
+  @Test
+  fun `error - a brand new exception is thrown instead`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: Exception) {
+              throw IllegalArgumentException()
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("The caught exception is swallowed")
+  }
+
+  @Test
+  fun `error - message is routed through a local variable`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: IllegalStateException) {
+              val message = e.message
+              throw IllegalArgumentException(message)
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("The caught exception is swallowed")
+  }
+
+  @Test
+  fun `error - message is routed through a variable declared in an outer block`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example(condition: Boolean) {
+            try {
+              doSomething()
+            } catch (e: IllegalStateException) {
+              val message = e.message
+              if (condition) {
+                throw IllegalArgumentException(message)
+              }
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("The caught exception is swallowed")
+  }
+
+  @Test
+  fun `clean - one of several throws passes the cause`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example(condition: Boolean) {
+            try {
+              doSomething()
+            } catch (e: IllegalStateException) {
+              if (condition) {
+                throw IllegalArgumentException(e)
+              }
+              throw IllegalArgumentException(e)
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - each swallowing catch in a chain is reported`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: IllegalStateException) {
+              throw IllegalArgumentException(e.message)
+            } catch (f: Exception) {
+              throw Exception(IllegalArgumentException(f.toString()))
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectWarningCount(2)
+  }
+
+  @Test
+  fun `error - nested catch is reported independently`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: IllegalStateException) {
+              try {
+                doSomething()
+              } catch (nested: Exception) {
+                throw IllegalArgumentException()
+              }
+              throw IllegalArgumentException(e)
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectWarningCount(1)
+  }
+
+  @Test
+  fun `clean - parameter name matches the allowed name pattern`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (ignored: Exception) {
+              println("nothing to do")
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - exception named underscore`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (_: Exception) {
+              println("failed")
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - ignored exception type in the catch clause`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: NumberFormatException) {
+              println("default")
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - ignored exception type thrown from the catch body`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: Exception) {
+              throw NumberFormatException("bad input")
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - configured ignored exception type`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: IllegalArgumentException) {
+              println("ignored")
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .configureOption(
+        SwallowedExceptionDetector.IGNORED_EXCEPTION_TYPES,
+        "IllegalArgumentException",
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - type missing from the configured ignore list`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: Exception) {
+              println("swallowed")
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .configureOption(
+        SwallowedExceptionDetector.IGNORED_EXCEPTION_TYPES,
+        "IllegalArgumentException",
+      )
+      .run()
+      .expectContains("The caught exception is swallowed")
+  }
+
+  @Test
+  fun `clean - configured allowed exception name`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (myIgnore: Exception) {
+              println("nothing to do")
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .configureOption(SwallowedExceptionDetector.ALLOWED_EXCEPTION_NAME, "myIgnore")
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - catch with an empty body`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: Exception) {
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("The caught exception is swallowed")
+  }
+}


### PR DESCRIPTION
# Change

Adds `SwallowedExceptionDetector`:

- Reports a catch block that never uses the caught exception
- `ignored-exception-types` (default `InterruptedException`, `MalformedURLException`, `NumberFormatException`, `ParseException`) matches both the catch clause and the catch body, since those types signal a nonexceptional outcome.
- `allowed-exception-name-regex` (default `_|(ignore|expected).*`) leaves deliberately-dropped exceptions alone.

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>