### PR TITLE
Add ThrowingExceptionsWithoutMessageDetector lint check

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/exceptions/ThrowingExceptionsWithoutMessageDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/exceptions/ThrowingExceptionsWithoutMessageDetector.kt
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.exceptions
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.StringOption
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UastCallKind
+import slack.lint.util.OptionLoadingDetector
+import slack.lint.util.StringSetLintOption
+import slack.lint.util.sourceImplementation
+
+class ThrowingExceptionsWithoutMessageDetector(
+  private val exceptionTypesOption: StringSetLintOption = StringSetLintOption(EXCEPTION_TYPES)
+) : OptionLoadingDetector(exceptionTypesOption), SourceCodeScanner {
+
+  override fun getApplicableUastTypes(): List<Class<out UElement>> =
+    listOf(UCallExpression::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    return object : UElementHandler() {
+      override fun visitCallExpression(node: UCallExpression) {
+        if (node.kind != UastCallKind.CONSTRUCTOR_CALL) return
+        if (node.valueArguments.isNotEmpty()) return
+        // A supertype call like `class Foo : Exception()` is also a constructor call, but a
+        // subclass declaring its own message is fine.
+        if (node.sourcePsi !is KtCallExpression) return
+
+        val className = node.resolve()?.containingClass?.name ?: return
+        if (className !in exceptionTypesOption.value) return
+
+        context.report(
+          ISSUE,
+          node,
+          context.getLocation(node),
+          "$className is created without a message or cause",
+        )
+      }
+    }
+  }
+
+  companion object {
+    private val DEFAULT_EXCEPTION_TYPES =
+      listOf(
+        "ArrayIndexOutOfBoundsException",
+        "Exception",
+        "IllegalArgumentException",
+        "IllegalMonitorStateException",
+        "IllegalStateException",
+        "IndexOutOfBoundsException",
+        "IOException",
+        "NullPointerException",
+        "RuntimeException",
+        "Throwable",
+      )
+
+    internal val EXCEPTION_TYPES =
+      StringOption(
+        "exception-types",
+        "Comma-separated list of exception type simple names to check.",
+        DEFAULT_EXCEPTION_TYPES.joinToString(","),
+        "Exceptions of these types must include a message or cause when created.",
+      )
+
+    val ISSUE =
+      Issue.create(
+          id = "ThrowingExceptionsWithoutMessageOrCause",
+          briefDescription = "Exception created without a message or cause",
+          explanation =
+            "Calling an exception's no-argument constructor leaves whoever reads the crash " +
+              "with nothing to work with. Pass a message describing what went wrong, or the " +
+              "underlying cause.",
+          category = Category.CORRECTNESS,
+          priority = 6,
+          severity = Severity.WARNING,
+          implementation = sourceImplementation<ThrowingExceptionsWithoutMessageDetector>(),
+        )
+        .setOptions(listOf(EXCEPTION_TYPES))
+  }
+}

--- a/slack-lint-checks/src/test/java/slack/lint/exceptions/ThrowingExceptionsWithoutMessageDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/exceptions/ThrowingExceptionsWithoutMessageDetectorTest.kt
@@ -1,0 +1,242 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.exceptions
+
+import com.android.tools.lint.checks.infrastructure.TestMode
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+
+class ThrowingExceptionsWithoutMessageDetectorTest : BaseSlackLintTest() {
+  override fun getDetector() = ThrowingExceptionsWithoutMessageDetector()
+
+  override fun getIssues() = listOf(ThrowingExceptionsWithoutMessageDetector.ISSUE)
+
+  override val skipTestModes =
+    arrayOf(
+      TestMode.WHITESPACE,
+      TestMode.SUPPRESSIBLE,
+      TestMode.PARENTHESIZED,
+      TestMode.FULLY_QUALIFIED,
+    )
+
+  @Test
+  fun `clean - exception thrown with a message`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            throw IllegalStateException("something broke")
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - exception thrown with a cause`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example(cause: Throwable) {
+            throw IllegalStateException(cause)
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - message passed as a named argument`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            throw IllegalStateException(message = "something broke")
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - exception thrown without a message`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            throw IllegalStateException()
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("IllegalStateException is created without a message or cause")
+  }
+
+  @Test
+  fun `error - IOException thrown without a message`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          import java.io.IOException
+
+          fun example() {
+            throw IOException()
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("IOException is created without a message or cause")
+  }
+
+  @Test
+  fun `error - exception constructed without being thrown`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            val error = IllegalArgumentException()
+            println(error)
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("IllegalArgumentException is created without a message or cause")
+  }
+
+  @Test
+  fun `error - argument-less exception nested as an argument`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            throw IllegalStateException(IllegalArgumentException())
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectWarningCount(1)
+      .expectContains("IllegalArgumentException is created without a message or cause")
+  }
+
+  @Test
+  fun `clean - exception type not in the list`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          class CustomException : Exception()
+
+          fun example() {
+            throw CustomException()
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - subclass calling a listed supertype constructor`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          class CustomException : IllegalStateException()
+
+          class WithBody : RuntimeException() {
+            fun describe() = "custom"
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - function whose name matches an exception ignoring case`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun illegalArgumentException() {
+            // no-op
+          }
+
+          fun example() {
+            illegalArgumentException()
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - type removed from the configured list`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            throw IllegalStateException()
+          }
+          """
+          )
+          .indented()
+      )
+      .configureOption(ThrowingExceptionsWithoutMessageDetector.EXCEPTION_TYPES, "Throwable")
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - type added to the configured list`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            throw UnsupportedOperationException()
+          }
+          """
+          )
+          .indented()
+      )
+      .configureOption(
+        ThrowingExceptionsWithoutMessageDetector.EXCEPTION_TYPES,
+        "UnsupportedOperationException",
+      )
+      .run()
+      .expectContains("UnsupportedOperationException is created without a message or cause")
+  }
+}


### PR DESCRIPTION
# Change

Adds `ThrowingExceptionsWithoutMessageDetector`:

- Reports argument-less construction of the common exception types, where the resulting crash carries no explanation of what went wrong.
- `exception-types` keeps `IOException` alongside the nine defaults

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>