### PR TITLE
Add TooGenericExceptionCaughtDetector lint check

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/exceptions/TooGenericExceptionCaughtDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/exceptions/TooGenericExceptionCaughtDetector.kt
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.exceptions
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.StringOption
+import org.jetbrains.kotlin.psi.KtCatchClause
+import org.jetbrains.uast.UCatchClause
+import org.jetbrains.uast.UElement
+import slack.lint.util.OptionLoadingDetector
+import slack.lint.util.StringSetLintOption
+import slack.lint.util.sourceImplementation
+
+private val DEFAULT_GENERIC_EXCEPTIONS =
+  listOf(
+    "ArrayIndexOutOfBoundsException",
+    "Error",
+    "Exception",
+    "IllegalMonitorStateException",
+    "IndexOutOfBoundsException",
+    "NullPointerException",
+    "RuntimeException",
+    "Throwable",
+  )
+
+private const val DEFAULT_ALLOWED_EXCEPTION_NAME = "_|(ignore|expected).*"
+
+class TooGenericExceptionCaughtDetector(
+  private val exceptionTypesOption: StringSetLintOption = StringSetLintOption(EXCEPTION_TYPES)
+) : OptionLoadingDetector(exceptionTypesOption), SourceCodeScanner {
+
+  override fun getApplicableUastTypes(): List<Class<out UElement>> =
+    listOf(UCatchClause::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    // Read as a whole string, not a set: a regex may legitimately contain a comma.
+    val allowedNamePattern =
+      Regex(
+        ALLOWED_EXCEPTION_NAME.getValue(context.configuration) ?: DEFAULT_ALLOWED_EXCEPTION_NAME
+      )
+    return object : UElementHandler() {
+      override fun visitCatchClause(node: UCatchClause) {
+        // A name like `_`, `ignored`, or `expected` says the throw was deliberately dropped.
+        val paramName = (node.sourcePsi as? KtCatchClause)?.catchParameter?.name
+        if (paramName != null && allowedNamePattern.matches(paramName)) return
+
+        for (typeRef in node.typeReferences) {
+          val typeName = typeRef.type.canonicalText.substringAfterLast('.')
+          if (typeName in exceptionTypesOption.value) {
+            context.report(
+              ISSUE,
+              node,
+              context.getLocation(typeRef),
+              "Caught exception type $typeName is too generic, so catch a more specific one",
+            )
+          }
+        }
+      }
+    }
+  }
+
+  companion object {
+    internal val EXCEPTION_TYPES =
+      StringOption(
+        "exception-types",
+        "Comma-separated list of generic exception simple names.",
+        DEFAULT_GENERIC_EXCEPTIONS.joinToString(","),
+        "Catching these exceptions is flagged as too generic.",
+      )
+
+    internal val ALLOWED_EXCEPTION_NAME =
+      StringOption(
+        "allowed-exception-name-regex",
+        "Regex for catch parameter names that are exempt from this check.",
+        DEFAULT_ALLOWED_EXCEPTION_NAME,
+        "Catch blocks whose parameter name matches this pattern are allowed.",
+      )
+
+    val ISSUE =
+      Issue.create(
+          id = "TooGenericExceptionCaught",
+          briefDescription = "Caught exception type is too generic",
+          explanation =
+            "Catching overly generic exceptions like `Exception` or `Throwable` " +
+              "can hide bugs and make error handling brittle. Catch more specific exception types.",
+          category = Category.CORRECTNESS,
+          priority = 6,
+          severity = Severity.WARNING,
+          implementation = sourceImplementation<TooGenericExceptionCaughtDetector>(),
+        )
+        .setOptions(listOf(EXCEPTION_TYPES, ALLOWED_EXCEPTION_NAME))
+  }
+}

--- a/slack-lint-checks/src/test/java/slack/lint/exceptions/TooGenericExceptionCaughtDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/exceptions/TooGenericExceptionCaughtDetectorTest.kt
@@ -1,0 +1,292 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.exceptions
+
+import com.android.tools.lint.checks.infrastructure.TestMode
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+
+class TooGenericExceptionCaughtDetectorTest : BaseSlackLintTest() {
+  override fun getDetector() = TooGenericExceptionCaughtDetector()
+
+  override fun getIssues() = listOf(TooGenericExceptionCaughtDetector.ISSUE)
+
+  override val skipTestModes = arrayOf(TestMode.WHITESPACE, TestMode.SUPPRESSIBLE)
+
+  @Test
+  fun `clean - specific exception caught`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: IllegalArgumentException) {
+              println(e.message)
+            }
+          }
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - generic exception caught`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: Exception) {
+              println(e.message)
+            }
+          }
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Caught exception type Exception is too generic")
+  }
+
+  @Test
+  fun `error - Throwable caught`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: Throwable) {
+              println(e.message)
+            }
+          }
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Caught exception type Throwable is too generic")
+  }
+
+  @Test
+  fun `clean - exception named ignored`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (ignored: Exception) {
+              println("skip")
+            }
+          }
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - exception named expected`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (expectedFailure: Throwable) {
+              println("skip")
+            }
+          }
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - every default generic type is reported`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try { doSomething() } catch (a: ArrayIndexOutOfBoundsException) { println(a) }
+            try { doSomething() } catch (b: Error) { println(b) }
+            try { doSomething() } catch (c: Exception) { println(c) }
+            try { doSomething() } catch (d: IllegalMonitorStateException) { println(d) }
+            try { doSomething() } catch (e: IndexOutOfBoundsException) { println(e) }
+            try { doSomething() } catch (g: NullPointerException) { println(g) }
+            try { doSomething() } catch (h: RuntimeException) { println(h) }
+            try { doSomething() } catch (i: Throwable) { println(i) }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectWarningCount(8)
+  }
+
+  @Test
+  fun `error - fully qualified generic type`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: java.lang.Exception) {
+              println(e)
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Caught exception type Exception is too generic")
+  }
+
+  @Test
+  fun `clean - custom subclass of a generic type`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          class MyException : RuntimeException()
+
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: MyException) {
+              println(e)
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - name only containing the allowed pattern`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (pleaseIgnoreThis: Exception) {
+              println("skip")
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Caught exception type Exception is too generic")
+  }
+
+  @Test
+  fun `clean - type removed from the configured list`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: Exception) {
+              println(e)
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .configureOption(TooGenericExceptionCaughtDetector.EXCEPTION_TYPES, "SomeOtherException")
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - configured allowed exception name`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (myIgnore: Exception) {
+              println("skip")
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .configureOption(TooGenericExceptionCaughtDetector.ALLOWED_EXCEPTION_NAME, "myIgnore")
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - exception named underscore`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (_: Exception) {
+              println("skip")
+            }
+          }
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+}


### PR DESCRIPTION
# Change

Adds `TooGenericExceptionCaughtDetector`:

- Reports catch blocks for the broad exception types (`Exception`, `Throwable`, `RuntimeException`, `NullPointerException`, and friends)
- `allowed-exception-name-regex` (default `_|(ignore|expected).*`) leaves deliberately-dropped exceptions alone. It matches the whole name, so `pleaseIgnoreThis` is still reported.
- `exception-types` replaces the default list when configured.

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>