### PR TITLE
Add TooGenericExceptionThrownDetector lint check

### DIFF
--- a/slack-lint-checks/src/main/java/slack/lint/exceptions/TooGenericExceptionThrownDetector.kt
+++ b/slack-lint-checks/src/main/java/slack/lint/exceptions/TooGenericExceptionThrownDetector.kt
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.exceptions
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.StringOption
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UQualifiedReferenceExpression
+import org.jetbrains.uast.UThrowExpression
+import org.jetbrains.uast.UastCallKind
+import org.jetbrains.uast.getParentOfType
+import slack.lint.util.OptionLoadingDetector
+import slack.lint.util.StringSetLintOption
+import slack.lint.util.sourceImplementation
+
+private val DEFAULT_GENERIC_EXCEPTIONS =
+  listOf("Error", "Exception", "RuntimeException", "Throwable")
+
+class TooGenericExceptionThrownDetector(
+  private val exceptionTypesOption: StringSetLintOption = StringSetLintOption(EXCEPTION_TYPES)
+) : OptionLoadingDetector(exceptionTypesOption), SourceCodeScanner {
+
+  override fun getApplicableUastTypes(): List<Class<out UElement>> =
+    listOf(UCallExpression::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    return object : UElementHandler() {
+      override fun visitCallExpression(node: UCallExpression) {
+        if (node.kind != UastCallKind.CONSTRUCTOR_CALL) return
+        // Only the exception being thrown counts, not one built to pass as an argument.
+        val throwExpression = node.getParentOfType<UThrowExpression>() ?: return
+        if (!throwExpression.throws(node)) return
+
+        val className = node.resolve()?.containingClass?.name ?: return
+        if (className in exceptionTypesOption.value) {
+          context.report(
+            ISSUE,
+            node,
+            context.getLocation(node),
+            "$className is too generic to throw, so throw a more specific exception",
+          )
+        }
+      }
+    }
+  }
+
+  /**
+   * Whether [call] is the exception this throws. A qualified name like `java.lang.Exception()` is
+   * wrapped in a reference expression, so the call is its selector rather than the thrown
+   * expression itself.
+   */
+  private fun UThrowExpression.throws(call: UCallExpression): Boolean {
+    val thrown = thrownExpression
+    return thrown === call || (thrown as? UQualifiedReferenceExpression)?.selector === call
+  }
+
+  companion object {
+    internal val EXCEPTION_TYPES =
+      StringOption(
+        "exception-types",
+        "Comma-separated list of generic exception simple names that should not be thrown.",
+        DEFAULT_GENERIC_EXCEPTIONS.joinToString(","),
+        "Throwing these exceptions is flagged as too generic.",
+      )
+
+    val ISSUE =
+      Issue.create(
+          id = "TooGenericExceptionThrown",
+          briefDescription = "Thrown exception type is too generic",
+          explanation =
+            "Throwing overly generic exceptions like `Exception` or `Throwable` " +
+              "makes it impossible for callers to handle specific error conditions. " +
+              "Throw a more specific exception type.",
+          category = Category.CORRECTNESS,
+          priority = 6,
+          severity = Severity.WARNING,
+          implementation = sourceImplementation<TooGenericExceptionThrownDetector>(),
+        )
+        .setOptions(listOf(EXCEPTION_TYPES))
+  }
+}

--- a/slack-lint-checks/src/test/java/slack/lint/exceptions/TooGenericExceptionThrownDetectorTest.kt
+++ b/slack-lint-checks/src/test/java/slack/lint/exceptions/TooGenericExceptionThrownDetectorTest.kt
@@ -1,0 +1,265 @@
+// Copyright (C) 2026 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+package slack.lint.exceptions
+
+import com.android.tools.lint.checks.infrastructure.TestMode
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+
+class TooGenericExceptionThrownDetectorTest : BaseSlackLintTest() {
+  override fun getDetector() = TooGenericExceptionThrownDetector()
+
+  override fun getIssues() = listOf(TooGenericExceptionThrownDetector.ISSUE)
+
+  override val skipTestModes =
+    arrayOf(
+      TestMode.WHITESPACE,
+      TestMode.SUPPRESSIBLE,
+      TestMode.PARENTHESIZED,
+      TestMode.FULLY_QUALIFIED,
+    )
+
+  @Test
+  fun `clean - specific exception thrown`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            throw IllegalArgumentException("bad input")
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - every default generic type is reported`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun throwsError() { throw Error() }
+
+          fun throwsException() { throw Exception() }
+
+          fun throwsRuntimeException() { throw RuntimeException() }
+
+          fun throwsThrowable() { throw Throwable() }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectWarningCount(4)
+  }
+
+  @Test
+  fun `error - generic exception thrown with a message`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            throw RuntimeException("oops")
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("RuntimeException is too generic to throw")
+  }
+
+  @Test
+  fun `clean - NullPointerException is not treated as generic`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            throw NullPointerException("npe")
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - generic exception constructed without being thrown`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            val error = Exception("built but not thrown")
+            println(error)
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - generic exception passed as an argument`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            throw IllegalStateException(Exception("cause"))
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - rethrowing a caught exception`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            try {
+              doSomething()
+            } catch (e: Exception) {
+              throw e
+            }
+          }
+
+          fun doSomething() {}
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - throwing the result of a factory call`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun makeException(): Exception = IllegalStateException("specific")
+
+          fun example() {
+            throw makeException()
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean - custom subclass of a generic type`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          class MyException : RuntimeException()
+
+          fun example() {
+            throw MyException()
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - fully qualified generic type`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            throw java.lang.RuntimeException("oops")
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("RuntimeException is too generic to throw")
+  }
+
+  @Test
+  fun `error - thrown from a local function`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            fun local() {
+              throw Exception("from a local function")
+            }
+            local()
+          }
+          """
+          )
+          .indented()
+      )
+      .run()
+      .expectContains("Exception is too generic to throw")
+  }
+
+  @Test
+  fun `clean - type removed from the configured list`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            throw RuntimeException("oops")
+          }
+          """
+          )
+          .indented()
+      )
+      .configureOption(TooGenericExceptionThrownDetector.EXCEPTION_TYPES, "SomeOtherException")
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `error - type added to the configured list`() {
+    lint()
+      .files(
+        kotlin(
+            """
+          fun example() {
+            throw UnsupportedOperationException("nope")
+          }
+          """
+          )
+          .indented()
+      )
+      .configureOption(
+        TooGenericExceptionThrownDetector.EXCEPTION_TYPES,
+        "UnsupportedOperationException",
+      )
+      .run()
+      .expectContains("UnsupportedOperationException is too generic to throw")
+  }
+}


### PR DESCRIPTION
# Change

Adds `TooGenericExceptionThrownDetector`, which reports throwing `Error`, `Exception`, `RuntimeException`, or `Throwable`. These leave callers no way to catch the specific failure they can handle.

- Only the thrown exception counts. Constructing one into a variable, or passing one as a cause, is left alone.
- The type is resolved rather than matched on source text, so a subclass of a broad type stays clean.
- `exception-types` replaces the default list.

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>